### PR TITLE
Handles exception when rs1090 service restarts

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,6 +13,7 @@ run cli: (build-image cli)
   {{cli}} run -it --rm --name tg -p 18000:18000 -e RS1090_SOURCE_BASE_URL=http://51.158.72.24:8080 tangram:0.1
 
 
+# TODO choose between -v & -e for source configuration
 run-dev cli:
   @{{cli}} run -it --rm --name tg-dev -p 18000:18000 \
     -v ./src:/home/user/tangram/src \
@@ -20,3 +21,12 @@ run-dev cli:
     -e RS1090_SOURCE_BASE_URL=http://51.158.72.24:8080 \
     tangram:0.1 \
     poetry run -- uvicorn --host 0.0.0.0 --port 18000 tangram.app:app --ws websockets --log-config=log.yml --reload
+
+tail-rs1090 cli:
+  @{{cli}} container exec -it tg-dev tail -f /tmp/tg-rs1090.log
+
+dev-repl cli:
+  {{cli}} container exec -it tg-dev /bin/bash
+
+
+# TODO make it easier for local venv development


### PR DESCRIPTION
When jet1090 process restarts, requests to its API endpoints fails. The plugin fail to recover and blocked in the task.

Now the exception is captured and task can move forward now.