### PR TITLE
feat(datalink): upgrade datalink to 0.3 and misc enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,16 +4,12 @@ version = 4
 
 [[package]]
 name = "acars"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377d68224a0870e909534f6b23b4d9621ffc921f2aa4282815f1e5ed4a4f3bf8"
+version = "0.3.0"
+source = "git+https://github.com/xoolive/datalink.git?rev=d3e3e5a5d2bda04fbee83832cb77e3050a87364c#d3e3e5a5d2bda04fbee83832cb77e3050a87364c"
 dependencies = [
  "base64",
  "deku",
- "flate2",
  "hex",
- "rasn",
- "rasn-atn-cpdlc",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -533,16 +529,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "bitvec-nom2"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988fcc40055ceaa85edc55875a08f8abd29018582647fd82ad6128dba14a5f0"
-dependencies = [
- "bitvec",
- "nom",
 ]
 
 [[package]]
@@ -1804,9 +1790,8 @@ dependencies = [
 
 [[package]]
 name = "datalink"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb5186121fd0ac256c2fc02e995a17cc4969119556657cdea4a39d2489ca23f"
+version = "0.3.0"
+source = "git+https://github.com/xoolive/datalink.git?rev=d3e3e5a5d2bda04fbee83832cb77e3050a87364c#d3e3e5a5d2bda04fbee83832cb77e3050a87364c"
 dependencies = [
  "acars",
  "chrono",
@@ -2644,15 +2629,6 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2970,12 +2946,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,16 +2988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "363b2defc9b4f195a84e7419e11e1b9af7df1f0ea62305fc5d1d04e93c536d65"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -3714,63 +3674,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
-name = "rasn"
-version = "0.28.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88235e585f2f3fc26ad809c79a84dd77e6a7203eb7d12e5bcaab89fc036d3d90"
-dependencies = [
- "bitvec",
- "bitvec-nom2",
- "bytes",
- "cfg-if",
- "chrono",
- "either",
- "nom",
- "num-bigint",
- "num-integer",
- "num-traits",
- "once_cell",
- "rasn-derive",
- "serde_json",
- "snafu",
- "xml-no-std",
-]
-
-[[package]]
-name = "rasn-atn-cpdlc"
-version = "0.28.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298c24650855709f4b62b2784f612c3b08058504398e0b8c7a76d291cbb295ff"
-dependencies = [
- "rasn",
-]
-
-[[package]]
-name = "rasn-derive"
-version = "0.28.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11dcd4dab09ceadedb3e2bedf340deb583f0e25bba9ad966b5655c2fb62b1392"
-dependencies = [
- "proc-macro2",
- "rasn-derive-impl",
- "syn",
-]
-
-[[package]]
-name = "rasn-derive-impl"
-version = "0.28.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f121c276d3f2fba8caabc870288de3f81abdb0bb94d5510651e58e1e00a7b9e7"
-dependencies = [
- "either",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "syn",
- "uuid",
-]
-
-[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4406,27 +4309,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "snafu"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
-dependencies = [
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "snap"
@@ -5992,12 +5874,6 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
-
-[[package]]
-name = "xml-no-std"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd223bc94c615fc02bf2f4bbc22a4a9bfe489c2add3ec10b1038df3aca44cac7"
 
 [[package]]
 name = "xxhash-rust"

--- a/packages/tangram_datalink/readme.md
+++ b/packages/tangram_datalink/readme.md
@@ -18,11 +18,11 @@ Setup the producer:
 ```sh
 # in tangram root
 git clone https://github.com/xoolive/datalink ../datalink
-
-# in the datalink checkout
 cd ../datalink
-git checkout 688407cf58bf13a99000c4c98104f12e33d074cd
-cargo run --release -- airframes --redis-url redis://127.0.0.1:6379
+# checkout to the supported version
+
+cargo run --release -- airframes.io --redis-url redis://127.0.0.1:6379
+cargo run --release -- vdl2 --redis-url redis://127.0.0.1:6379 capture.raw
 
 # optional: inspect the normalized event stream in redis
 podman exec -i redis redis-cli PSUBSCRIBE 'datalink-*'

--- a/packages/tangram_datalink/rust/Cargo.toml
+++ b/packages/tangram_datalink/rust/Cargo.toml
@@ -16,7 +16,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 tangram_core_rs = { path = "../../tangram_core/rust" }
 # datalink = { path = "../../../../datalink/crates/datalink", default-features = false }
-datalink = { version = "0.2.0", default-features = false }
+datalink = { git = "https://github.com/xoolive/datalink.git", rev = "d3e3e5a5d2bda04fbee83832cb77e3050a87364c", default-features = false }
+# datalink = { version = "0.3.0", default-features = false }
 
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/packages/tangram_datalink/rust/src/state.rs
+++ b/packages/tangram_datalink/rust/src/state.rs
@@ -5,6 +5,7 @@ use datalink::event::{AirframesAddrType, DecodedEvent, ProtocolMessage};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tangram_core::stream::{Identifiable, Positioned, StateCollection, Tracked};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatalinkAircraftInfo {
@@ -234,6 +235,7 @@ impl DatalinkStateVectors {
     }
 
     fn add_aircraft(&mut self, env: &DecodedEvent, update: AircraftUpdate) {
+        let event_time = event_time(env);
         let ac = self
             .entities
             .entry(update.id.clone())
@@ -275,10 +277,11 @@ impl DatalinkStateVectors {
                 .and_then(|a| a.flight_id.clone())
                 .or(update.flight_id),
         });
-        apply_kinematics(ac, env, self.expire);
+        apply_kinematics(ac, env, self.expire, event_time);
     }
 
     fn add_station(&mut self, env: &DecodedEvent, update: StationUpdate) {
+        let event_time = event_time(env);
         let station = self
             .entities
             .entry(update.id.clone())
@@ -313,33 +316,34 @@ impl DatalinkStateVectors {
             frequency_mhz: update.frequency_mhz,
             supported_frequencies_mhz: update.supported_frequencies_mhz,
         });
-        if let Some(ts) = env.timestamp {
-            station.lastseen = station.lastseen.max(ts);
-        }
+        station.lastseen = station.lastseen.max(event_time);
         station.messages += 1;
         if let (Some(latitude), Some(longitude)) = (update.latitude, update.longitude) {
             station.latitude = Some(latitude);
             station.longitude = Some(longitude);
-            if let Some(ts) = env.timestamp {
-                station.position_time = Some(ts);
-            }
+            station.position_time = Some(event_time);
         }
     }
 }
 
-fn apply_kinematics(entity: &mut DatalinkEntity, env: &DecodedEvent, expire: u16) {
-    if let Some(ts) = env.timestamp {
-        entity.lastseen = entity.lastseen.max(ts);
-    }
+fn event_time(env: &DecodedEvent) -> f64 {
+    env.timestamp.unwrap_or_else(|| {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs_f64()
+    })
+}
+
+fn apply_kinematics(entity: &mut DatalinkEntity, env: &DecodedEvent, expire: u16, event_time: f64) {
+    entity.lastseen = entity.lastseen.max(event_time);
     entity.messages += 1;
 
     if let Some(pos) = &env.kinematics {
         if let Some(position) = pos.position {
             entity.latitude = Some(position.latitude);
             entity.longitude = Some(position.longitude);
-            if let Some(ts) = env.timestamp {
-                entity.position_time = Some(ts);
-            }
+            entity.position_time = Some(event_time);
         }
         if pos.altitude_ft.is_some() {
             entity.altitude_ft = pos.altitude_ft;

--- a/packages/tangram_datalink/src/tangram_datalink/DatalinkInfoWidget.vue
+++ b/packages/tangram_datalink/src/tangram_datalink/DatalinkInfoWidget.vue
@@ -259,7 +259,7 @@ const feedRows = computed<FeedRow[]>(() => {
   const keyCounts = new Map<string, number>();
   for (const item of entityList.value) {
     for (const msg of getMessages(item.id)) {
-      const rawMsg = markRaw(toRaw(msg) as DatalinkMessage);
+      const rawMsg = markRaw(toRaw(msg));
       const category = classifyCategory(rawMsg);
       const baseKey = feedMessageKey(item.id, rawMsg);
       const keyCount = keyCounts.get(baseKey) ?? 0;

--- a/packages/tangram_datalink/src/tangram_datalink/DatalinkLayer.vue
+++ b/packages/tangram_datalink/src/tangram_datalink/DatalinkLayer.vue
@@ -271,7 +271,7 @@ watch(
     }
 
     type Seg = { from: [number, number]; to: [number, number] };
-    type Dot = { pos: [number, number]; eta_secs?: number; altitude_ft?: number };
+    type Dot = { pos: [number, number] };
     const routeSegments: Seg[] = [];
     const routeDots: Dot[] = [];
 
@@ -293,7 +293,12 @@ watch(
       const cur: [number, number] = [curLon, curLat];
 
       // Collect all waypoints in ETA order
-      type Wpt = { lon: number; lat: number; eta_secs?: number; altitude_ft?: number };
+      type Wpt = {
+        lon: number;
+        lat: number;
+        eta_seconds_past_hour?: number;
+        altitude_ft?: number;
+      };
       const waypoints: Wpt[] = [];
 
       const hasPredictedRoute = adsc.next != null;
@@ -304,7 +309,7 @@ watch(
         waypoints.push({
           lon: adsc.next.longitude,
           lat: adsc.next.latitude,
-          eta_secs: adsc.next.eta_secs,
+          eta_seconds_past_hour: adsc.next.eta_seconds_past_hour,
           altitude_ft: adsc.next.altitude_ft
         });
         if (adsc.next_next) {
@@ -319,7 +324,7 @@ watch(
       if (!hasPredictedRoute) {
         // IntermediateProjection: project from current position
         for (const ip of adsc.intermediate_projections ?? []) {
-          if (!ip.track_invalid) {
+          if (!ip.track_invalid && ip.track_degrees != null) {
             const [pLon, pLat] = projectPoint(
               curLat,
               curLon,
@@ -329,7 +334,7 @@ watch(
             waypoints.push({
               lon: pLon,
               lat: pLat,
-              eta_secs: ip.eta_secs,
+              eta_seconds_past_hour: ip.eta_seconds_past_hour,
               altitude_ft: ip.altitude_ft
             });
           }
@@ -340,19 +345,26 @@ watch(
           waypoints.push({
             lon: fp.longitude,
             lat: fp.latitude,
-            eta_secs: fp.eta_secs,
+            eta_seconds_past_hour: fp.eta_seconds_past_hour,
             altitude_ft: fp.altitude_ft
           });
         }
       }
 
-      // Sort by ETA when available; keep unknowns at end
-      waypoints.sort((a, b) => {
-        if (a.eta_secs == null && b.eta_secs == null) return 0;
-        if (a.eta_secs == null) return 1;
-        if (b.eta_secs == null) return -1;
-        return a.eta_secs - b.eta_secs;
-      });
+      const etaOrder = (secondsPastHour: number | undefined) => {
+        if (secondsPastHour == null) return Number.POSITIVE_INFINITY;
+        const eta = ((secondsPastHour % 3600) + 3600) % 3600;
+        const report = adsc.report_seconds_past_hour;
+        if (report == null) return eta;
+        const reference = ((report % 3600) + 3600) % 3600;
+        return (eta - reference + 3600) % 3600;
+      };
+
+      // ADS-C encodes ETA as seconds past the hour. Sort by elapsed time from
+      // the report so points remain ordered correctly across an hour boundary.
+      waypoints.sort(
+        (a, b) => etaOrder(a.eta_seconds_past_hour) - etaOrder(b.eta_seconds_past_hour)
+      );
 
       // Build segments: unwrap each longitude relative to the previous point
       // so no segment ever crosses the antimeridian the long way around.
@@ -361,11 +373,7 @@ watch(
         const lon = unwrapLon(wpt.lon, prev[0]);
         const next: [number, number] = [lon, wpt.lat];
         routeSegments.push({ from: prev, to: next });
-        routeDots.push({
-          pos: next,
-          eta_secs: wpt.eta_secs,
-          altitude_ft: wpt.altitude_ft
-        });
+        routeDots.push({ pos: next });
         prev = next;
       }
     }

--- a/packages/tangram_datalink/src/tangram_datalink/index.ts
+++ b/packages/tangram_datalink/src/tangram_datalink/index.ts
@@ -14,7 +14,8 @@ import {
   datalinkStore,
   classifyAndStore,
   ensureHistory,
-  getSquitterPayload
+  getSquitterPayload,
+  messageFlightId
 } from "./store";
 import type { DatalinkMessage } from "./types";
 
@@ -86,7 +87,7 @@ export function getMessageEntityId(msg: DatalinkMessage) {
   return (
     normalizeId(msg.aircraft?.icao24) ||
     normalizeId(msg.aircraft?.registration) ||
-    normalizeId(msg.flight_id) ||
+    normalizeId(messageFlightId(msg)) ||
     normalizeId(msg.aircraft?.aircraft_id) ||
     "unknown"
   );

--- a/packages/tangram_datalink/src/tangram_datalink/store.ts
+++ b/packages/tangram_datalink/src/tangram_datalink/store.ts
@@ -3,23 +3,17 @@ import type { DatalinkEntity } from "./index";
 import type {
   AcarsAppPayload,
   AcarsMessage,
-  AdscContractGroup,
-  AdscTag,
+  AdscPositionReport,
   Arinc622Message,
-  CpdlcElementBody,
-  CpdlcPhraseFragment,
-  CpdlcTimestamp,
+  Arinc622Payload,
   DatalinkAdscReport,
-  DatalinkCpdlcElement,
-  DatalinkCpdlcMessage,
   DatalinkMessage,
-  JsonObject,
+  DatalinkProtocolMessage,
   SquitterPayload
 } from "./types";
 
 export interface DatalinkEntityHistory {
   adsc: DatalinkAdscReport[];
-  cpdlc: DatalinkCpdlcMessage[];
   /** all raw messages for the general feed tab */
   messages: DatalinkMessage[];
   /** set of category ids seen for this entity */
@@ -28,7 +22,6 @@ export interface DatalinkEntityHistory {
 
 const HISTORY_LIMIT = 200;
 const ADSC_LIMIT = 50;
-const CPDLC_LIMIT = 100;
 
 export const MESSAGE_CATEGORIES = [
   {
@@ -83,9 +76,18 @@ export const MESSAGE_CATEGORIES = [
 export type MessageCategoryId = (typeof MESSAGE_CATEGORIES)[number]["id"];
 
 function defaultCategories(): Record<MessageCategoryId, boolean> {
-  const out = {} as Record<MessageCategoryId, boolean>;
-  for (const c of MESSAGE_CATEGORIES) out[c.id] = true;
-  return out;
+  return {
+    adsc: true,
+    cpdlc: true,
+    afn: true,
+    text: true,
+    miam: true,
+    position: true,
+    aoc: true,
+    oooi: true,
+    xid: true,
+    other: true
+  };
 }
 
 export const STATION_CATEGORIES = [
@@ -137,7 +139,7 @@ export const datalinkStore: DatalinkStore = shallowReactive({
   selectedIds: new Set<string>(),
   /** universal per-entity message history, keyed by entity id, populated regardless of selection */
   history: new Map<string, DatalinkEntityHistory>(),
-  filter: makeDefaultFilter() as DatalinkFilter,
+  filter: makeDefaultFilter(),
   version: 0
 });
 
@@ -145,7 +147,6 @@ export function ensureHistory(id: string): DatalinkEntityHistory {
   if (!datalinkStore.history.has(id)) {
     datalinkStore.history.set(id, {
       adsc: [],
-      cpdlc: [],
       messages: [],
       categories: new Set()
     });
@@ -158,122 +159,123 @@ function ringPrepend<T>(arr: T[], item: T, limit: number) {
   if (arr.length > limit) arr.length = limit;
 }
 
-const isObject = (value: unknown): value is JsonObject =>
-  value !== null && typeof value === "object" && !Array.isArray(value);
+export const messageKind = (message: DatalinkProtocolMessage): string => {
+  if ("airframes" in message) return "airframes";
+  if ("avlc" in message) return "avlc";
+  if ("acars" in message) return "acars";
+  if ("hfdl" in message) return "hfdl";
+  return "app";
+};
 
-const asObject = (value: unknown): JsonObject | null =>
-  isObject(value) ? value : null;
+export const arinc622PayloadKind = (payload: Arinc622Payload): string => {
+  if ("adsc" in payload) return "adsc";
+  if ("adsc_disconnect" in payload) return "adsc_disconnect";
+  if ("cpdlc" in payload) return "cpdlc";
+  if ("aoc" in payload) return "aoc";
+  return "unknown";
+};
 
-export const messageData = (msg: DatalinkMessage): JsonObject | null =>
-  asObject(msg.message.data);
-
-const avlcAcarsMessage = (msg: DatalinkMessage): AcarsMessage | undefined => {
-  if (msg.message.kind !== "avlc") return undefined;
-  return msg.message.data.payload?.kind === "acars"
-    ? msg.message.data.payload.data
-    : undefined;
+export const avlcAcarsMessage = (msg: DatalinkMessage): AcarsMessage | undefined => {
+  if (!("avlc" in msg.message)) return undefined;
+  const payload = msg.message.avlc.payload;
+  return payload && "acars" in payload ? payload.acars : undefined;
 };
 
 export const messageLabel = (msg: DatalinkMessage): string | undefined => {
-  switch (msg.message.kind) {
-    case "airframes":
-      return msg.message.data.payload.label ?? undefined;
-    case "acars":
-      return msg.message.data.label ?? undefined;
-    case "avlc":
-      return avlcAcarsMessage(msg)?.label ?? undefined;
-    case "app":
-    case "hfdl":
-      return undefined;
+  if ("airframes" in msg.message)
+    return msg.message.airframes.payload.label ?? undefined;
+  if ("acars" in msg.message) return msg.message.acars.label ?? undefined;
+  if ("avlc" in msg.message) return avlcAcarsMessage(msg)?.label ?? undefined;
+  return undefined;
+};
+
+export const messageFlightId = (msg: DatalinkMessage): string | number | undefined => {
+  if ("airframes" in msg.message)
+    return msg.message.airframes.payload.flight_id ?? undefined;
+  if ("acars" in msg.message) return msg.message.acars.flight_id;
+  if ("avlc" in msg.message) return avlcAcarsMessage(msg)?.flight_id;
+  if ("app" in msg.message) {
+    const app = msg.message.app;
+    if (
+      typeof app !== "string" &&
+      "arinc622" in app &&
+      "adsc" in app.arinc622.payload
+    ) {
+      for (const tag of app.arinc622.payload.adsc) {
+        if (typeof tag !== "string" && "flight_id" in tag)
+          return tag.flight_id.callsign;
+      }
+    }
   }
+  return undefined;
 };
 
 export const messageApp = (
   msg: DatalinkMessage
 ): AcarsAppPayload | null | undefined => {
-  switch (msg.message.kind) {
-    case "app":
-      return msg.message.data;
-    case "acars":
-    case "airframes":
-      return msg.message.data.app;
-    case "avlc":
-      return avlcAcarsMessage(msg)?.app;
-    case "hfdl":
-      return undefined;
-  }
+  if ("app" in msg.message) return msg.message.app;
+  if ("acars" in msg.message) return msg.message.acars.app;
+  if ("airframes" in msg.message) return msg.message.airframes.app;
+  if ("avlc" in msg.message) return avlcAcarsMessage(msg)?.app;
+  return undefined;
 };
 
 export const getSquitterPayload = (msg: DatalinkMessage): SquitterPayload | null => {
   const app = messageApp(msg);
-  return app?.kind === "squitter" ? app.data : null;
+  return app && typeof app !== "string" && "squitter" in app ? app.squitter : null;
 };
 
 export const arinc622Payload = (
   app: AcarsAppPayload | null | undefined
-): Arinc622Message | null => (app?.kind === "arinc622" ? app.data : null);
+): Arinc622Message | null =>
+  app && typeof app !== "string" && "arinc622" in app ? app.arinc622 : null;
 
-const stringField = (obj: JsonObject, key: string): string | undefined => {
-  const value = obj[key];
-  return typeof value === "string" ? value : undefined;
-};
-
-const numberField = (obj: JsonObject, key: string): number | undefined => {
-  const value = obj[key];
-  return typeof value === "number" ? value : undefined;
-};
-
-const arrayField = (obj: JsonObject, key: string): unknown[] => {
-  const value = obj[key];
-  return Array.isArray(value) ? value : [];
+export const adscDisconnectReason = (msg: DatalinkMessage): string | null => {
+  const arinc = arinc622Payload(messageApp(msg));
+  return arinc?.imi === "DIS" && "adsc_disconnect" in arinc.payload
+    ? arinc.payload.adsc_disconnect
+    : null;
 };
 
 export function classifyCategory(msg: DatalinkMessage): MessageCategoryId {
-  const avlcPayload = msg.message.kind === "avlc" ? msg.message.data.payload : null;
-  if (avlcPayload?.kind === "xid" || avlcPayload?.kind === "x25") return "xid";
+  if ("avlc" in msg.message) {
+    const payload = msg.message.avlc.payload;
+    if (payload && ("xid" in payload || "x25" in payload)) return "xid";
+  }
 
   const app = messageApp(msg);
-  if (!app || app.kind === "none") return "other";
+  if (!app || app === "none" || app === "link_test") return "other";
+  if (typeof app === "string") return "other";
+  if ("squitter" in app) return "other";
 
-  if (getSquitterPayload(msg)) return "other";
-
-  const arinc = arinc622Payload(app);
-  if (arinc) {
-    const imi = arinc.imi ?? "";
-    if (imi === "ADS") return "adsc";
+  if ("arinc622" in app) {
+    const imi = app.arinc622.imi;
+    if (imi === "ADS" || imi === "DIS") return "adsc";
     if (["AT1", "CR1", "CC1", "DR1"].includes(imi)) return "cpdlc";
     if (imi === "AFN" || imi === "ATS") return "afn";
     return "other";
   }
 
-  switch (app.kind) {
-    case "afn":
-      return "afn";
-    case "text":
-      return "text";
-    case "miam":
-    case "ohma":
-      return "miam";
-    case "media_advisory":
-    case "aoc_position":
-      return "position";
-    case "label_32":
-      return app.data.latitude != null && app.data.longitude != null
-        ? "position"
-        : "aoc";
-    case "oooi_off_destination":
-    case "oooi_off_report":
-      return "oooi";
-    case "aoc_report":
-    case "oceanic_clearance":
-    case "atis_delivery":
-    case "atis_request":
-    case "weather":
-    case "label_5z":
-    case "label_16":
-    case "label_37":
-      return "aoc";
-  }
+  if ("afn" in app) return "afn";
+  if ("text" in app) return "text";
+  if ("miam" in app || "ohma" in app) return "miam";
+  if ("media_advisory" in app || "aoc_position" in app) return "position";
+  if ("label_32" in app)
+    return app.label_32.latitude != null && app.label_32.longitude != null
+      ? "position"
+      : "aoc";
+  if ("oooi_off_destination" in app || "oooi_off_report" in app) return "oooi";
+  if (
+    "aoc_report" in app ||
+    "oceanic_clearance" in app ||
+    "atis_delivery" in app ||
+    "atis_request" in app ||
+    "weather" in app ||
+    "label_5z" in app ||
+    "label_16" in app ||
+    "label_37" in app
+  )
+    return "aoc";
 
   const label = messageLabel(msg);
   if (label) {
@@ -281,249 +283,115 @@ export function classifyCategory(msg: DatalinkMessage): MessageCategoryId {
     if (["QF", "QQ", "Q0"].includes(label)) return "oooi";
     if (label === "H1") return "cpdlc";
   }
-
   return "other";
 }
 
-const objectField = (obj: JsonObject, key: string): JsonObject | null => {
-  const value = obj[key];
-  return isObject(value) ? value : null;
+const setPositionReport = (report: DatalinkAdscReport, value: AdscPositionReport) => {
+  report.position = { latitude: value.latitude, longitude: value.longitude };
+  report.altitude_ft = value.altitude_ft;
+  report.report_seconds_past_hour = value.timestamp_seconds_past_hour;
 };
 
-const cpdlcTimestamp = (value: unknown): CpdlcTimestamp | undefined => {
-  const timestamp = asObject(value);
-  if (!timestamp) return undefined;
-  return {
-    hour: numberField(timestamp, "hour"),
-    minute: numberField(timestamp, "minute"),
-    second: numberField(timestamp, "second")
-  };
-};
-
-const cpdlcHeader = (value: unknown): DatalinkCpdlcMessage["header"] => {
-  const header = asObject(value);
-  if (!header) return undefined;
-  return {
-    msg_id: numberField(header, "msg_id"),
-    msg_ref: numberField(header, "msg_ref"),
-    timestamp: cpdlcTimestamp(header.timestamp)
-  };
-};
-
-const cpdlcElement = (value: unknown): DatalinkCpdlcElement | null => {
-  const element = asObject(value);
-  if (!element) return null;
-  const id = numberField(element, "id");
-  if (id == null) return null;
-  const fragments = arrayField(element, "fragments")
-    .map(fragment => {
-      const value = asObject(fragment);
-      if (!value) return null;
-      const kind = stringField(value, "kind");
-      const data = value.data;
-      if (kind === "text" && typeof data === "string")
-        return { kind: "text", data } satisfies CpdlcPhraseFragment;
-      if (kind === "value" && typeof data === "string")
-        return { kind: "value", data } satisfies CpdlcPhraseFragment;
-      return null;
-    })
-    .filter(isPresent);
-  const body = asObject(element.body) as CpdlcElementBody | null;
-  return {
-    id,
-    catalog_name: stringField(element, "catalog_name"),
-    fragments,
-    body,
-    is_additional: element.is_additional === true
-  };
-};
-
-const isPresent = <T>(value: T | null | undefined): value is T => value != null;
+const hasTrajectoryData = (report: DatalinkAdscReport): boolean =>
+  report.position != null ||
+  report.track != null ||
+  report.next != null ||
+  report.next_next != null ||
+  Boolean(report.intermediate_projections?.length) ||
+  Boolean(report.fixed_projections?.length);
 
 export function classifyAndStore(id: string, msg: DatalinkMessage) {
   const hist = ensureHistory(id);
   ringPrepend(hist.messages, msg, HISTORY_LIMIT);
-
   hist.categories.add(classifyCategory(msg));
   datalinkStore.version++;
 
   const arinc = arinc622Payload(messageApp(msg));
   if (!arinc) return;
 
-  const imi = arinc.imi ?? "";
-  const payload = arinc.payload;
-
-  if (imi === "ADS" && payload?.kind === "adsc") {
-    const tags = (payload.data.tags ?? []) as AdscTag[];
+  if (arinc.imi === "ADS" && "adsc" in arinc.payload) {
+    const tags = arinc.payload.adsc;
     const report: DatalinkAdscReport = {
       timestamp: msg.timestamp ?? undefined,
       registration: arinc.registration,
-      atsu_address: arinc.atsu_address,
-      raw_tags: tags.map(tag => tag.kind)
+      atsu_address: arinc.atsu_address
     };
 
     for (const tag of tags) {
-      switch (tag.kind) {
-        case "basic_report":
-        case "emergency_basic_report":
-        case "waypoint_change_event":
-        case "lateral_deviation_change_event":
-        case "vertical_rate_change_event":
-        case "altitude_range_event": {
-          report.position = {
-            latitude: tag.data.latitude,
-            longitude: tag.data.longitude
-          };
-          report.altitude_ft = tag.data.altitude_ft;
-          break;
-        }
-        case "flight_id":
-          report.flight_id = tag.data.id;
-          break;
-        case "predicted_route":
-          report.next = {
-            latitude: tag.data.next_latitude,
-            longitude: tag.data.next_longitude,
-            altitude_ft: tag.data.next_altitude_ft,
-            eta_secs: tag.data.next_eta_seconds
-          };
-          if (
-            tag.data.next_next_latitude != null &&
-            tag.data.next_next_longitude != null
-          ) {
-            report.next_next = {
-              latitude: tag.data.next_next_latitude,
-              longitude: tag.data.next_next_longitude,
-              altitude_ft: tag.data.next_next_altitude_ft
-            };
-          }
-          break;
-        case "earth_reference_data":
-          if (tag.data.heading_invalid !== true) {
-            report.track = tag.data.heading_or_track_degrees;
-          }
-          report.ground_speed_kt = tag.data.speed;
-          report.vertical_speed_fpm = tag.data.vertical_speed_ft_per_min;
-          break;
-        case "air_reference_data":
-          if (report.track == null && tag.data.heading_invalid !== true) {
-            report.track = tag.data.heading_or_track_degrees;
-          }
-          break;
-        case "intermediate_projection": {
-          const { distance_nm, track_degrees } = tag.data;
-          if (distance_nm != null && track_degrees != null) {
-            report.intermediate_projections ??= [];
-            report.intermediate_projections.push({
-              distance_nm,
-              track_degrees,
-              track_invalid: tag.data.track_invalid === true,
-              altitude_ft: tag.data.altitude_ft,
-              eta_secs: tag.data.eta_seconds
-            });
-          }
-          break;
-        }
-        case "fixed_projection": {
-          const { latitude, longitude } = tag.data;
-          if (latitude != null && longitude != null) {
-            report.fixed_projections ??= [];
-            report.fixed_projections.push({
-              latitude,
-              longitude,
-              altitude_ft: tag.data.altitude_ft,
-              eta_secs: tag.data.eta_seconds
-            });
-          }
-          break;
-        }
-        case "meteo_data":
-          report.wind_speed_kt = tag.data.wind_speed_kt;
-          if (tag.data.wind_direction_invalid !== true) {
-            report.wind_direction_deg = tag.data.wind_direction_true_degrees;
-          }
-          report.temperature_c = tag.data.temperature_c;
-          break;
-        case "periodic_contract_request":
-        case "event_contract_request":
-        case "emergency_periodic_contract_request":
-          report.is_uplink = true;
-          report.contract = {
-            kind:
-              tag.kind === "periodic_contract_request"
-                ? "periodic"
-                : tag.kind === "event_contract_request"
-                  ? "event"
-                  : "emergency",
-            number: tag.data.contract_number,
-            groups: (tag.data.groups ?? []).map((group: AdscContractGroup) => {
-              const value = "data" in group && isObject(group.data) ? group.data : {};
-              return {
-                kind: group.kind,
-                interval_secs: numberField(value, "interval_secs"),
-                modulus: numberField(value, "modulus"),
-                threshold_nm: numberField(value, "threshold_nm"),
-                threshold_fpm: numberField(value, "threshold_ft_per_min"),
-                ceiling_ft: numberField(value, "ceiling_ft"),
-                floor_ft: numberField(value, "floor_ft"),
-                projection_time_mins: numberField(value, "projection_time_mins")
-              };
-            })
-          };
-          break;
-        case "cancel_all_contracts":
-          report.is_uplink = true;
-          report.contract = { kind: "cancel_all", groups: [] };
-          break;
-        case "cancel_contract":
-          report.is_uplink = true;
-          report.contract = {
-            kind: "cancel",
-            number: tag.data.contract_number,
-            groups: []
-          };
-          break;
+      if (typeof tag === "string") continue;
+      if ("basic_report" in tag) {
+        setPositionReport(report, tag.basic_report);
+      } else if ("emergency_basic_report" in tag) {
+        setPositionReport(report, tag.emergency_basic_report);
+      } else if ("waypoint_change_event" in tag) {
+        setPositionReport(report, tag.waypoint_change_event);
+      } else if ("lateral_deviation_change_event" in tag) {
+        setPositionReport(report, tag.lateral_deviation_change_event);
+      } else if ("vertical_rate_change_event" in tag) {
+        setPositionReport(report, tag.vertical_rate_change_event);
+      } else if ("altitude_range_event" in tag) {
+        setPositionReport(report, tag.altitude_range_event);
+      } else if ("flight_id" in tag) {
+        report.flight_id = tag.flight_id.callsign;
+      } else if ("airframe_id" in tag) {
+        report.icao24 = tag.airframe_id.icao24.toLowerCase();
+      } else if ("predicted_route" in tag) {
+        const route = tag.predicted_route;
+        report.next = {
+          latitude: route.next_latitude,
+          longitude: route.next_longitude,
+          altitude_ft: route.next_altitude_ft,
+          eta_seconds_past_hour: route.next_eta_seconds
+        };
+        report.next_next = {
+          latitude: route.next_next_latitude,
+          longitude: route.next_next_longitude,
+          altitude_ft: route.next_next_altitude_ft
+        };
+      } else if ("earth_reference_data" in tag) {
+        const data = tag.earth_reference_data;
+        if (!data.track_invalid) report.track = data.true_track_degrees;
+        report.ground_speed_kt = data.ground_speed_kt;
+        report.vertical_speed_fpm = data.vertical_speed_ft_per_min;
+      } else if ("air_reference_data" in tag) {
+        const data = tag.air_reference_data;
+        if (report.track == null && !data.heading_invalid)
+          report.track = data.true_heading_degrees;
+      } else if ("intermediate_projection" in tag) {
+        const data = tag.intermediate_projection;
+        report.intermediate_projections ??= [];
+        report.intermediate_projections.push({
+          distance_nm: data.distance_nm,
+          track_degrees: data.track_degrees,
+          track_invalid: data.track_invalid === true || data.track_degrees == null,
+          altitude_ft: data.altitude_ft,
+          eta_seconds_past_hour: data.eta_seconds
+        });
+      } else if ("fixed_projection" in tag) {
+        const data = tag.fixed_projection;
+        report.fixed_projections ??= [];
+        report.fixed_projections.push({
+          latitude: data.latitude,
+          longitude: data.longitude,
+          altitude_ft: data.altitude_ft,
+          eta_seconds_past_hour: data.eta_seconds
+        });
+      } else if ("meteo_data" in tag) {
+        const data = tag.meteo_data;
+        report.wind_speed_kt = data.wind_speed_kt;
+        if (!data.wind_direction_invalid)
+          report.wind_direction_deg = data.wind_direction_true_degrees;
+        report.temperature_c = data.temperature_c;
       }
     }
 
     if (report.track == null && report.intermediate_projections) {
-      const first = report.intermediate_projections.find(ip => !ip.track_invalid);
+      const first = report.intermediate_projections.find(
+        projection => !projection.track_invalid && projection.track_degrees != null
+      );
       if (first) report.track = first.track_degrees;
     }
-
-    ringPrepend(hist.adsc, report, ADSC_LIMIT);
+    if (hasTrajectoryData(report)) ringPrepend(hist.adsc, report, ADSC_LIMIT);
     return;
-  }
-
-  if (["AT1", "CR1", "CC1", "DR1"].includes(imi) && payload?.kind === "cpdlc") {
-    const decodedPayload = payload.data;
-    const cpdlcMsg: DatalinkCpdlcMessage = {
-      timestamp: msg.timestamp ?? undefined,
-      atsu_address: arinc.atsu_address,
-      registration: arinc.registration,
-      imi,
-      elements: []
-    };
-
-    const control = objectField(decodedPayload, "control");
-    if (control) cpdlcMsg.control_type = stringField(control, "kind");
-
-    const downlink = objectField(decodedPayload, "downlink");
-    const uplink = objectField(decodedPayload, "uplink");
-    const controlData = control ? objectField(control, "data") : null;
-    const controlSide = controlData ? objectField(controlData, "message") : null;
-    const side = downlink ?? uplink ?? controlSide;
-
-    if (side) {
-      cpdlcMsg.direction = downlink ? "downlink" : "uplink";
-      cpdlcMsg.header = cpdlcHeader(side.header);
-      cpdlcMsg.elements = arrayField(side, "elements")
-        .map(cpdlcElement)
-        .filter(isPresent);
-    } else if (control && !cpdlcMsg.elements.length) {
-      cpdlcMsg.direction = "uplink";
-    }
-
-    ringPrepend(hist.cpdlc, cpdlcMsg, CPDLC_LIMIT);
   }
 }

--- a/packages/tangram_datalink/src/tangram_datalink/summary/Adsc.vue
+++ b/packages/tangram_datalink/src/tangram_datalink/summary/Adsc.vue
@@ -5,16 +5,20 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import type {
+  AdscAirReferenceData,
   AdscContractGroup,
+  AdscEarthReferenceData,
   AdscMeteoData,
-  AdscPayload,
+  AdscNackReason,
+  AdscNoncomplianceNotification,
+  AdscNoncompliantTag,
   AdscPositionReport,
   AdscPredictedRoute,
-  AdscReferenceData,
   AdscTag,
   DatalinkMessage
 } from "../types";
 import { arinc622Message } from "../summary_helpers";
+import { adscDisconnectReason } from "../store";
 import SummaryRows from "./Rows.vue";
 import type { SummaryRow } from "../types";
 
@@ -32,8 +36,7 @@ const props = defineProps<{ msg: DatalinkMessage }>();
 
 const tags = (msg: DatalinkMessage): AdscTag[] => {
   const payload = arinc622Message(msg)?.payload;
-  if (payload?.kind !== "adsc") return [];
-  return ((payload.data as AdscPayload).tags ?? []) as AdscTag[];
+  return payload && "adsc" in payload ? payload.adsc : [];
 };
 
 const FLIGHT_LEVEL_MIN_FEET = 10_000;
@@ -54,9 +57,16 @@ const formatPosition = (report: AdscPositionReport) =>
     .filter(Boolean)
     .join(" ");
 
-const formatEta = (seconds: number) => {
-  const minutes = Math.round(seconds / 60);
-  return minutes <= 0 ? "+0m" : `+${minutes}m`;
+const formatEta = (secondsPastHour: number, reportSecondsPastHour?: number) => {
+  if (reportSecondsPastHour == null) {
+    const normalized = ((Math.round(secondsPastHour) % 3600) + 3600) % 3600;
+    const minute = Math.floor(normalized / 60);
+    const second = normalized % 60;
+    return `ETA :${String(minute).padStart(2, "0")}:${String(second).padStart(2, "0")}`;
+  }
+  const delta =
+    ((secondsPastHour % 3600) - (reportSecondsPastHour % 3600) + 3600) % 3600;
+  return `+${Math.round(delta / 60)}m`;
 };
 
 const reportMeta = (report: AdscPositionReport) => {
@@ -74,17 +84,21 @@ const routePoint = (
   latitude: number,
   longitude: number,
   altitude?: number,
-  eta?: number
+  eta?: number,
+  reportSecondsPastHour?: number
 ) =>
   [
     `${latitude.toFixed(2)}° ${longitude.toFixed(2)}°`,
     altitude == null ? null : formatAltitude(altitude),
-    eta == null ? null : formatEta(eta)
+    eta == null ? null : formatEta(eta, reportSecondsPastHour)
   ]
     .filter(Boolean)
     .join(" ");
 
-const routeRows = (route: AdscPredictedRoute): SummaryRow[] => {
+const routeRows = (
+  route: AdscPredictedRoute,
+  reportSecondsPastHour?: number
+): SummaryRow[] => {
   const rows = [
     {
       meta: "next",
@@ -92,7 +106,8 @@ const routeRows = (route: AdscPredictedRoute): SummaryRow[] => {
         route.next_latitude,
         route.next_longitude,
         route.next_altitude_ft,
-        route.next_eta_seconds
+        route.next_eta_seconds,
+        reportSecondsPastHour
       )
     }
   ];
@@ -109,24 +124,39 @@ const routeRows = (route: AdscPredictedRoute): SummaryRow[] => {
   return rows;
 };
 
-const referenceDetail = (value: AdscReferenceData, label: string) => {
+const earthReferenceDetail = (value: AdscEarthReferenceData) => {
   const parts = [
-    value.heading_or_track_degrees == null || value.heading_invalid
+    value.true_track_degrees == null || value.track_invalid
       ? null
-      : `${Math.round(value.heading_or_track_degrees)}°`,
-    value.speed == null ? null : `${Math.round(value.speed)} kt`,
+      : `${Math.round(value.true_track_degrees)}°`,
+    value.ground_speed_kt == null ? null : `${Math.round(value.ground_speed_kt)} kt`,
     value.vertical_speed_ft_per_min == null || value.vertical_speed_ft_per_min === 0
       ? null
       : formatSigned(value.vertical_speed_ft_per_min, " fpm")
   ].filter(Boolean);
-  return parts.length ? `${label} ${parts.join(" ")}` : `${label} data`;
+  return parts.length ? `track ${parts.join(" ")}` : "track data";
+};
+
+const airReferenceDetail = (value: AdscAirReferenceData) => {
+  const parts = [
+    value.true_heading_degrees == null || value.heading_invalid
+      ? null
+      : `${Math.round(value.true_heading_degrees)}°`,
+    value.mach == null ? null : `M${value.mach.toFixed(3)}`,
+    value.vertical_speed_ft_per_min == null || value.vertical_speed_ft_per_min === 0
+      ? null
+      : formatSigned(value.vertical_speed_ft_per_min, " fpm")
+  ].filter(Boolean);
+  return parts.length ? `heading ${parts.join(" ")}` : "heading data";
 };
 
 const meteoDetail = (value: AdscMeteoData) => {
   const parts = [
-    value.wind_speed_kt == null || value.wind_direction_invalid
+    value.wind_speed_kt == null ||
+    value.wind_direction_true_degrees == null ||
+    value.wind_direction_invalid
       ? null
-      : `wind ${Math.round(value.wind_direction_true_degrees ?? 0)}°/${Math.round(
+      : `wind ${Math.round(value.wind_direction_true_degrees)}°/${Math.round(
           value.wind_speed_kt
         )} kt`,
     value.temperature_c == null ? null : formatSigned(value.temperature_c, "°C")
@@ -134,123 +164,59 @@ const meteoDetail = (value: AdscMeteoData) => {
   return parts.length ? parts.join(" ") : "meteo data";
 };
 
-const groupData = (group: AdscContractGroup): Record<string, unknown> =>
-  "data" in group && group.data !== null && typeof group.data === "object"
-    ? group.data
-    : {};
-
-const groupNumber = (group: AdscContractGroup, key: string): number | undefined => {
-  const value = groupData(group)[key];
-  return typeof value === "number" ? value : undefined;
-};
-
-const contractGroupLabel = (group: AdscContractGroup) => {
-  switch (group.kind) {
-    case "report_interval": {
-      const intervalSecs = groupNumber(group, "interval_secs");
-      return intervalSecs == null ? "interval" : `every ${intervalSecs}s`;
-    }
-    case "flight_id":
-      return "flight id";
-    case "predicted_route":
-      return "route";
-    case "earth_reference_data":
-      return "earth ref";
-    case "air_reference_data":
-      return "air ref";
-    case "meteo_data":
-      return "meteo";
-    case "airframe_id":
-      return "airframe";
-    case "aircraft_intent_data": {
-      const projectionTimeMins = groupNumber(group, "projection_time_mins");
-      return projectionTimeMins == null ? "intent" : `intent +${projectionTimeMins}m`;
-    }
-    default:
-      return null;
-  }
-};
-
 const groupDetail = (group: AdscContractGroup) => {
-  switch (group.kind) {
-    case "report_interval": {
-      const intervalSecs = groupNumber(group, "interval_secs");
-      return intervalSecs == null ? "interval" : `every ${intervalSecs}s`;
-    }
-    case "flight_id":
-      return "flight id";
-    case "predicted_route":
-      return "route";
-    case "earth_reference_data":
-      return "earth ref";
-    case "air_reference_data":
-      return "air ref";
-    case "meteo_data":
-      return "meteo";
-    case "airframe_id":
-      return "airframe";
-    case "lateral_deviation_change": {
-      const thresholdNm = groupNumber(group, "threshold_nm");
-      return thresholdNm == null ? "lat dev" : `lat dev >${thresholdNm} nm`;
-    }
-    case "vertical_speed_change": {
-      const thresholdFpm = groupNumber(group, "threshold_ft_per_min");
-      return thresholdFpm == null
-        ? "vs change"
-        : `vs ${formatSigned(thresholdFpm, " fpm")}`;
-    }
-    case "altitude_range": {
-      const floorFt = groupNumber(group, "floor_ft");
-      const ceilingFt = groupNumber(group, "ceiling_ft");
-      return floorFt == null || ceilingFt == null
-        ? "alt range"
-        : `alt ${formatAltitude(floorFt)}-${formatAltitude(ceilingFt)}`;
-    }
-    case "report_waypoint_changes":
-      return "waypoint change";
-    case "aircraft_intent_data": {
-      const projectionTimeMins = groupNumber(group, "projection_time_mins");
-      return projectionTimeMins == null ? "intent" : `intent +${projectionTimeMins}m`;
-    }
-    default:
-      return group.kind.replaceAll("_", " ");
-  }
+  if (group === "waypoint_change") return "waypoint change";
+  if ("flight_id" in group) return "flight id";
+  if ("predicted_route" in group) return "route";
+  if ("earth_reference_data" in group) return "earth ref";
+  if ("air_reference_data" in group) return "air ref";
+  if ("meteo_data" in group) return "meteo";
+  if ("airframe_id" in group) return "airframe";
+  if ("lateral_deviation_change" in group)
+    return `lat dev >${group.lateral_deviation_change.threshold_nm} nm`;
+  if ("vertical_speed_change" in group)
+    return `vs ${formatSigned(group.vertical_speed_change.threshold_ft_per_min, " fpm")}`;
+  if ("altitude_range" in group)
+    return `alt ${formatAltitude(group.altitude_range.floor_ft)}-${formatAltitude(
+      group.altitude_range.ceiling_ft
+    )}`;
+  return `intent +${group.aircraft_intent_data.projection_time_mins}m`;
 };
 
 const contractFeatureSummary = (groups: AdscContractGroup[]) => {
-  const labels = groups
-    .map(contractGroupLabel)
-    .filter((label): label is string => Boolean(label));
-  if (!labels.length) return null;
-  return `request ${labels.join(", ")}`;
+  const labels = groups.map(groupDetail);
+  return labels.length ? `request ${labels.join(", ")}` : null;
 };
 
-const contractRows = (
-  tag: Extract<
-    AdscTag,
-    {
-      kind:
-        | "periodic_contract_request"
-        | "event_contract_request"
-        | "emergency_periodic_contract_request";
-    }
-  >
-): SummaryRow[] => {
-  const label =
-    tag.kind === "periodic_contract_request"
-      ? "periodic contract"
-      : tag.kind === "event_contract_request"
-        ? "event contract"
-        : "emergency contract";
-  const groups = tag.data.groups ?? [];
-  const reportInterval = groups.find(group => group.kind === "report_interval");
+const contractRows = (tag: AdscTag): SummaryRow[] => {
+  if (typeof tag === "string") return [];
+  if ("event_contract_request" in tag) {
+    const data = tag.event_contract_request;
+    return [
+      {
+        meta: "event contract",
+        detail: [`#${data.contract_number}`, contractFeatureSummary(data.events)]
+          .filter(Boolean)
+          .join(" · ")
+      }
+    ];
+  }
+
+  const data =
+    "periodic_contract_request" in tag
+      ? tag.periodic_contract_request
+      : "emergency_periodic_contract_request" in tag
+        ? tag.emergency_periodic_contract_request
+        : null;
+  if (!data) return [];
   return [
     {
-      meta: label,
+      meta:
+        "periodic_contract_request" in tag ? "periodic contract" : "emergency contract",
       detail: [
-        tag.data.contract_number == null ? null : `#${tag.data.contract_number}`,
-        reportInterval ? groupDetail(reportInterval) : null,
-        contractFeatureSummary(groups.filter(group => group.kind !== "report_interval"))
+        `#${data.contract_number}`,
+        `every ${data.report_interval_secs}s`,
+        contractFeatureSummary(data.requested_groups)
       ]
         .filter(Boolean)
         .join(" · ")
@@ -262,85 +228,110 @@ const positionRow = (meta: string, report: AdscPositionReport): SummaryRow[] => 
   { meta, detail: `${formatPosition(report)}${reportMeta(report)}` }
 ];
 
-const rowsForTag = (tag: AdscTag): SummaryRow[] => {
-  switch (tag.kind) {
-    case "acknowledgement":
-      return [
-        {
-          meta: "ack",
-          detail:
-            tag.data.contract_number == null
-              ? "contract"
-              : `contract #${tag.data.contract_number}`
-        }
-      ];
-    case "negative_acknowledgement":
-      return [
-        {
-          meta: "nak",
-          detail:
-            [
-              tag.data.contract_request_number == null
-                ? null
-                : `request #${tag.data.contract_request_number}`,
-              tag.data.reason
-            ]
-              .filter(Boolean)
-              .join(" · ") || "request rejected"
-        }
-      ];
-    case "noncompliance_notification":
-      return [{ meta: "noncompliance", detail: "contract cannot be satisfied" }];
-    case "cancel_emergency_mode":
-      return [{ meta: "emergency", detail: "cancel emergency mode" }];
-    case "basic_report":
-      return positionRow("report", tag.data);
-    case "emergency_basic_report":
-      return positionRow("emergency", tag.data);
-    case "lateral_deviation_change_event":
-      return positionRow("lat dev", tag.data);
-    case "vertical_rate_change_event":
-      return positionRow("vs event", tag.data);
-    case "altitude_range_event":
-      return positionRow("alt range", tag.data);
-    case "waypoint_change_event":
-      return positionRow("waypoint", tag.data);
-    case "flight_id":
-      return tag.data.id ? [{ meta: "flight", detail: tag.data.id }] : [];
-    case "predicted_route":
-      return routeRows(tag.data);
-    case "earth_reference_data":
-      return [{ meta: "earth", detail: referenceDetail(tag.data, "track") }];
-    case "air_reference_data":
-      return [{ meta: "air", detail: referenceDetail(tag.data, "heading") }];
-    case "meteo_data":
-      return [{ meta: "meteo", detail: meteoDetail(tag.data) }];
-    case "airframe_id":
-      return [{ meta: "airframe", detail: "icao address group" }];
-    case "intermediate_projection":
-      return [{ meta: "intent", detail: "intermediate projected intent" }];
-    case "fixed_projection":
-      return [{ meta: "intent", detail: "fixed projected intent" }];
-    case "cancel_all_contracts":
-      return [{ meta: "cancel", detail: "all contracts" }];
-    case "cancel_contract":
-      return [
-        {
-          meta: "cancel",
-          detail:
-            tag.data.contract_number == null
-              ? "contract"
-              : `contract #${tag.data.contract_number}`
-        }
-      ];
-    case "periodic_contract_request":
-    case "event_contract_request":
-    case "emergency_periodic_contract_request":
-      return contractRows(tag);
-    default:
-      return [{ meta: tag.kind, detail: "unrendered ADS-C tag" }];
-  }
+const adscEnumLabel = (value: AdscNackReason | AdscNoncompliantTag) => {
+  if (typeof value === "string") return value.replaceAll("_", " ");
+  const unknown = value.unknown;
+  return "code" in unknown
+    ? `unknown (code ${unknown.code})`
+    : `unknown (tag ${unknown.tag})`;
 };
 
-const rows = computed(() => tags(props.msg).flatMap(rowsForTag));
+const noncomplianceDetail = (value: AdscNoncomplianceNotification) => {
+  const groups = value.groups.map(group => adscEnumLabel(group.noncompliant_tag));
+  return (
+    [
+      `request #${value.contract_request_number}`,
+      groups.length ? groups.join(", ") : null
+    ]
+      .filter(Boolean)
+      .join(" · ") || "contract cannot be satisfied"
+  );
+};
+
+const positionReport = (tag: AdscTag): AdscPositionReport | undefined => {
+  if (typeof tag === "string") return undefined;
+  if ("basic_report" in tag) return tag.basic_report;
+  if ("emergency_basic_report" in tag) return tag.emergency_basic_report;
+  if ("lateral_deviation_change_event" in tag)
+    return tag.lateral_deviation_change_event;
+  if ("vertical_rate_change_event" in tag) return tag.vertical_rate_change_event;
+  if ("altitude_range_event" in tag) return tag.altitude_range_event;
+  if ("waypoint_change_event" in tag) return tag.waypoint_change_event;
+  return undefined;
+};
+
+const rowsForTag = (tag: AdscTag, reportSecondsPastHour?: number): SummaryRow[] => {
+  if (tag === "cancel_emergency_mode")
+    return [{ meta: "emergency", detail: "cancel emergency mode" }];
+  if (tag === "cancel_all_contracts")
+    return [{ meta: "cancel", detail: "all contracts" }];
+  if ("acknowledgement" in tag)
+    return [
+      { meta: "ack", detail: `contract #${tag.acknowledgement.contract_number}` }
+    ];
+  if ("negative_acknowledgement" in tag) {
+    const data = tag.negative_acknowledgement;
+    return [
+      {
+        meta: "nak",
+        detail: [
+          `request #${data.contract_request_number}`,
+          adscEnumLabel(data.reason)
+        ].join(" · ")
+      }
+    ];
+  }
+  if ("noncompliance_notification" in tag)
+    return [
+      {
+        meta: "noncompliance",
+        detail: noncomplianceDetail(tag.noncompliance_notification)
+      }
+    ];
+  if ("basic_report" in tag) return positionRow("report", tag.basic_report);
+  if ("emergency_basic_report" in tag)
+    return positionRow("emergency", tag.emergency_basic_report);
+  if ("lateral_deviation_change_event" in tag)
+    return positionRow("lat dev", tag.lateral_deviation_change_event);
+  if ("vertical_rate_change_event" in tag)
+    return positionRow("vs event", tag.vertical_rate_change_event);
+  if ("altitude_range_event" in tag)
+    return positionRow("alt range", tag.altitude_range_event);
+  if ("waypoint_change_event" in tag)
+    return positionRow("waypoint", tag.waypoint_change_event);
+  if ("flight_id" in tag) return [{ meta: "flight", detail: tag.flight_id.callsign }];
+  if ("predicted_route" in tag)
+    return routeRows(tag.predicted_route, reportSecondsPastHour);
+  if ("earth_reference_data" in tag)
+    return [{ meta: "earth", detail: earthReferenceDetail(tag.earth_reference_data) }];
+  if ("air_reference_data" in tag)
+    return [{ meta: "air", detail: airReferenceDetail(tag.air_reference_data) }];
+  if ("meteo_data" in tag)
+    return [{ meta: "meteo", detail: meteoDetail(tag.meteo_data) }];
+  if ("airframe_id" in tag)
+    return [{ meta: "airframe", detail: `icao24 ${tag.airframe_id.icao24}` }];
+  if ("intermediate_projection" in tag)
+    return [{ meta: "intent", detail: "intermediate projected intent" }];
+  if ("fixed_projection" in tag)
+    return [{ meta: "intent", detail: "fixed projected intent" }];
+  if ("cancel_contract" in tag)
+    return [
+      { meta: "cancel", detail: `contract #${tag.cancel_contract.contract_number}` }
+    ];
+  return contractRows(tag);
+};
+
+const rows = computed<SummaryRow[]>(() => {
+  const disconnect = adscDisconnectReason(props.msg);
+  if (disconnect)
+    return [{ meta: "disconnect", detail: disconnect.replaceAll("_", " ") }];
+
+  const decodedTags = tags(props.msg);
+  const reference = decodedTags
+    .map(positionReport)
+    .find(
+      report => report?.timestamp_seconds_past_hour != null
+    )?.timestamp_seconds_past_hour;
+  return decodedTags.flatMap(tag => rowsForTag(tag, reference));
+});
 </script>

--- a/packages/tangram_datalink/src/tangram_datalink/summary/Afn.vue
+++ b/packages/tangram_datalink/src/tangram_datalink/summary/Afn.vue
@@ -5,10 +5,9 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { messageApp } from "../store";
-import type { DatalinkMessage } from "../types";
+import type { DatalinkMessage, SummaryRow } from "../types";
 import { arinc622Message } from "../summary_helpers";
 import SummaryRows from "./Rows.vue";
-import type { SummaryRow } from "../types";
 
 defineOptions({ name: "DatalinkSummaryAfn" });
 
@@ -16,7 +15,7 @@ const props = defineProps<{ msg: DatalinkMessage }>();
 
 const rows = computed<SummaryRow[]>(() => {
   const app = messageApp(props.msg);
-  if (app?.kind !== "afn") {
+  if (!app || typeof app === "string" || !("afn" in app)) {
     const arinc = arinc622Message(props.msg);
     return arinc?.imi === "AFN" || arinc?.imi === "ATS"
       ? [
@@ -27,11 +26,11 @@ const rows = computed<SummaryRow[]>(() => {
         ].filter(row => row.detail)
       : [];
   }
-  const data = app.data;
-  const apps = (data.applications ?? [])
-    .map(app => [app.code, app.value].filter(Boolean).join(" "))
-    .filter(Boolean);
 
+  const data = app.afn;
+  const applications = (data.applications ?? [])
+    .map(application => [application.code, application.value].filter(Boolean).join(" "))
+    .filter(Boolean);
   return [
     {
       meta: `AFN ${data.message_type}`,
@@ -39,7 +38,9 @@ const rows = computed<SummaryRow[]>(() => {
         .filter(Boolean)
         .join(" · ")
     },
-    ...(apps.length ? [{ meta: "apps", detail: apps.slice(0, 4).join(" · ") }] : [])
+    ...(applications.length
+      ? [{ meta: "apps", detail: applications.slice(0, 4).join(" · ") }]
+      : [])
   ].filter(row => row.detail);
 });
 </script>

--- a/packages/tangram_datalink/src/tangram_datalink/summary/Aoc.vue
+++ b/packages/tangram_datalink/src/tangram_datalink/summary/Aoc.vue
@@ -5,10 +5,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { messageApp } from "../store";
-import type { DatalinkMessage } from "../types";
-import type { Label5zPayload } from "../types";
+import type { DatalinkMessage, Label5zPayload, SummaryRow } from "../types";
 import SummaryRows from "./Rows.vue";
-import type { SummaryRow } from "../types";
 
 defineOptions({ name: "DatalinkSummaryAoc" });
 
@@ -35,134 +33,139 @@ const label5zRows = (data: Label5zPayload): SummaryRow[] => {
 
 const rows = computed<SummaryRow[]>(() => {
   const app = messageApp(props.msg);
-  switch (app?.kind) {
-    case "oceanic_clearance": {
-      const data = app.data;
-      const clearance = [data.clearance_type, data.clearance_number]
-        .filter(Boolean)
-        .join(" ");
-      return [
-        {
-          meta: "oceanic",
-          detail: [data.facility, clearance || null, data.flight_id]
-            .filter(Boolean)
-            .join(" · ")
-        },
-        {
-          meta: "entry",
-          detail: [
-            data.entry_point,
-            time(data.entry_time),
-            data.mach,
-            data.flight_level
-          ]
-            .filter(Boolean)
-            .join(" · ")
-        }
-      ].filter(row => row.detail);
-    }
-    case "atis_request": {
-      const data = app.data;
-      return [
-        {
-          meta: "ATIS req",
-          detail: [
-            data.airport,
-            `current ${data.current_atis}`,
-            `offset ${data.offset}`
-          ].join(" · ")
-        }
-      ];
-    }
-    case "atis_delivery": {
-      const data = app.data;
-      return [
-        {
-          meta: "ATIS",
-          detail: [data.airport, data.kind, data.atis_letter, data.issued_time]
-            .filter(Boolean)
-            .join(" · ")
-        }
-      ];
-    }
-    case "weather": {
-      const reports = app.data.reports ?? [];
-      const first = reports[0];
-      return [
-        {
-          meta: "weather",
-          detail: [
-            reports.length ? `${reports.length} reports` : null,
-            reports
-              .map(report => report.station)
-              .slice(0, 4)
-              .join(" ") || null,
-            first ? [first.day, first.time].filter(Boolean).join("/") : null
-          ]
-            .filter(Boolean)
-            .join(" · ")
-        }
-      ];
-    }
-    case "aoc_report": {
-      const data = app.data;
-      return [
-        {
-          meta: data.msg_type,
-          detail: [
-            data.flight_number,
-            data.departure && data.destination
-              ? `${data.departure} → ${data.destination}`
-              : null,
-            time(data.eta),
-            data.flight_level == null ? null : `FL${data.flight_level}`
-          ]
-            .filter(Boolean)
-            .join(" · ")
-        }
-      ].filter(row => row.detail);
-    }
-    case "label_5z":
-      return label5zRows(app.data);
-    case "label_32":
-      return [
-        {
-          meta: "label 32",
-          detail: [
-            app.data.timestamp ? `${app.data.timestamp}Z` : null,
-            app.data.latitude != null && app.data.longitude != null
-              ? `${app.data.latitude.toFixed(2)} ${app.data.longitude.toFixed(2)}`
-              : null,
-            app.data.altitude_ft == null ? null : `${app.data.altitude_ft} ft`,
-            `${app.data.fields.length} fields`
-          ]
-            .filter(Boolean)
-            .join(" · ")
-        }
-      ];
-    case "label_16":
-      return [
-        {
-          meta: "label 16",
-          detail: [
-            app.data.timestamp ? `${app.data.timestamp}Z` : null,
-            `${app.data.fields.length} fields`
-          ]
-            .filter(Boolean)
-            .join(" · ")
-        }
-      ];
-    case "label_37":
-      return [
-        {
-          meta: "label 37",
-          detail: [`${app.data.line_count} lines`, app.data.prefix]
-            .filter(Boolean)
-            .join(" · ")
-        }
-      ];
-    default:
-      return [];
+  if (!app || typeof app === "string") return [];
+
+  if ("oceanic_clearance" in app) {
+    const data = app.oceanic_clearance;
+    const clearance = [data.clearance_type, data.clearance_number]
+      .filter(Boolean)
+      .join(" ");
+    return [
+      {
+        meta: "oceanic",
+        detail: [data.facility, clearance || null, data.flight_id]
+          .filter(Boolean)
+          .join(" · ")
+      },
+      {
+        meta: "entry",
+        detail: [data.entry_point, time(data.entry_time), data.mach, data.flight_level]
+          .filter(Boolean)
+          .join(" · ")
+      }
+    ].filter(row => row.detail);
   }
+
+  if ("atis_request" in app) {
+    const data = app.atis_request;
+    return [
+      {
+        meta: "ATIS req",
+        detail: [
+          data.airport,
+          `current ${data.current_atis}`,
+          `offset ${data.offset}`
+        ].join(" · ")
+      }
+    ];
+  }
+
+  if ("atis_delivery" in app) {
+    const data = app.atis_delivery;
+    return [
+      {
+        meta: "ATIS",
+        detail: [data.airport, data.kind, data.atis_letter, data.issued_time]
+          .filter(Boolean)
+          .join(" · ")
+      }
+    ];
+  }
+
+  if ("weather" in app) {
+    const reports = app.weather.reports ?? [];
+    const first = reports[0];
+    return [
+      {
+        meta: "weather",
+        detail: [
+          reports.length ? `${reports.length} reports` : null,
+          reports
+            .map(report => report.station)
+            .slice(0, 4)
+            .join(" ") || null,
+          first ? [first.day, first.time].filter(Boolean).join("/") : null
+        ]
+          .filter(Boolean)
+          .join(" · ")
+      }
+    ];
+  }
+
+  if ("aoc_report" in app) {
+    const data = app.aoc_report;
+    return [
+      {
+        meta: data.msg_type,
+        detail: [
+          data.flight_number,
+          data.departure && data.destination
+            ? `${data.departure} → ${data.destination}`
+            : null,
+          time(data.eta),
+          data.flight_level == null ? null : `FL${data.flight_level}`
+        ]
+          .filter(Boolean)
+          .join(" · ")
+      }
+    ].filter(row => row.detail);
+  }
+
+  if ("label_5z" in app) return label5zRows(app.label_5z);
+
+  if ("label_32" in app) {
+    const data = app.label_32;
+    return [
+      {
+        meta: "label 32",
+        detail: [
+          data.timestamp ? `${data.timestamp}Z` : null,
+          data.latitude != null && data.longitude != null
+            ? `${data.latitude.toFixed(2)} ${data.longitude.toFixed(2)}`
+            : null,
+          data.altitude_ft == null ? null : `${data.altitude_ft} ft`,
+          `${data.fields.length} fields`
+        ]
+          .filter(Boolean)
+          .join(" · ")
+      }
+    ];
+  }
+
+  if ("label_16" in app) {
+    const data = app.label_16;
+    return [
+      {
+        meta: "label 16",
+        detail: [
+          data.timestamp ? `${data.timestamp}Z` : null,
+          `${data.fields.length} fields`
+        ]
+          .filter(Boolean)
+          .join(" · ")
+      }
+    ];
+  }
+
+  if ("label_37" in app) {
+    const data = app.label_37;
+    return [
+      {
+        meta: "label 37",
+        detail: [`${data.line_count} lines`, data.prefix].filter(Boolean).join(" · ")
+      }
+    ];
+  }
+  return [];
 });
 </script>

--- a/packages/tangram_datalink/src/tangram_datalink/summary/Cpdlc.vue
+++ b/packages/tangram_datalink/src/tangram_datalink/summary/Cpdlc.vue
@@ -14,13 +14,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import type {
-  AdjacentPayload,
-  Arinc622Payload,
-  CpdlcPayload,
-  DatalinkCpdlcElement,
+  CpdlcElement,
   DatalinkMessage,
-  JsonObject,
-  JsonValue,
   PhraseSummaryRow,
   SummaryPhrasePart
 } from "../types";
@@ -48,14 +43,14 @@ const controlLabel = (kind: string) => {
   }
 };
 
-const primitive = (value: JsonValue | undefined): string | null => {
+const primitive = (value: unknown): string | null => {
   if (value == null) return null;
   if (typeof value === "string") return value;
   if (typeof value === "number" || typeof value === "boolean") return String(value);
   return null;
 };
 
-const formatTime = (value: JsonObject) => {
+const formatTime = (value: Record<string, unknown>) => {
   const hour = typeof value.hour === "number" ? value.hour : null;
   const minute = typeof value.minute === "number" ? value.minute : null;
   const second = typeof value.second === "number" ? value.second : null;
@@ -63,7 +58,7 @@ const formatTime = (value: JsonObject) => {
   return `${String(hour).padStart(2, "0")}${String(minute).padStart(2, "0")}${second == null ? "" : String(second).padStart(2, "0")}Z`;
 };
 
-const formatAdjacent = (kind: string, data: JsonValue): string | null => {
+const formatVariant = (kind: string, data: unknown): string | null => {
   const direct = primitive(data);
   switch (kind) {
     case "flight_level":
@@ -90,13 +85,16 @@ const formatAdjacent = (kind: string, data: JsonValue): string | null => {
     case "vhf_khz":
       return typeof data === "number" ? `${(data / 1000).toFixed(3)} MHz` : direct;
     case "indicated_knots":
+    case "true_knots":
     case "ground_knots":
       return direct == null ? null : `${direct} kt`;
     case "indicated_kmh":
+    case "true_kmh":
     case "ground_kmh":
       return direct == null ? null : `${direct} km/h`;
-    case "mach_thousandths":
-      return typeof data === "number" ? `M${(data / 1000).toFixed(2)}` : direct;
+    case "mach":
+    case "mach_large":
+      return typeof data === "number" ? `M${(data / 100).toFixed(2)}` : direct;
     case "nm":
     case "nautical_miles":
       return direct == null ? null : `${direct} nm`;
@@ -125,76 +123,81 @@ const formatAdjacent = (kind: string, data: JsonValue): string | null => {
   }
 };
 
-const formatValue = (value: JsonValue | undefined): string => {
+const formatValue = (value: unknown): string => {
   const direct = primitive(value);
   if (direct != null) return direct;
   if (Array.isArray(value)) return value.map(formatValue).join(" / ");
   if (!isRecord(value)) return "—";
   const time = formatTime(value);
   if (time) return time;
-  if (typeof value.kind === "string" && "data" in value) {
-    const formatted = formatAdjacent(value.kind, value.data as JsonValue);
-    return formatted ?? label(value.kind);
+
+  const entries = Object.entries(value);
+  if (entries.length === 1) {
+    const [kind, data] = entries[0];
+    return formatVariant(kind, data) ?? label(kind);
   }
-  return Object.entries(value)
-    .map(([key, entry]) => `${label(key)} ${formatValue(entry as JsonValue)}`)
+  return entries
+    .map(([key, entry]) => `${label(key)} ${formatValue(entry)}`)
     .join(" · ");
 };
 
-const resolveSlot = (
-  element: DatalinkCpdlcElement,
-  slot: string
-): JsonValue | undefined => {
+const resolveSlot = (element: CpdlcElement, slot: string): unknown => {
   const body = element.body;
-  if (!body) return undefined;
-  if (body.kind === slot) return body.data;
-  return isRecord(body.data) ? (body.data[slot] as JsonValue | undefined) : undefined;
+  if (!body || body === "unsupported") return undefined;
+  const entries = Object.entries(body);
+  if (entries.length !== 1) return undefined;
+  const [kind, data] = entries[0];
+  if (kind === slot) return data;
+  return isRecord(data) && slot in data ? data[slot] : undefined;
 };
 
-const renderElement = (element: DatalinkCpdlcElement): PhrasePart[] => {
-  if (element.fragments.length) {
-    return element.fragments.map(fragment => {
-      if (fragment.kind === "text") return { kind: "text", text: fragment.data };
-      const value = resolveSlot(element, fragment.data);
-      return {
-        kind: "value",
-        text: value === undefined ? `${label(fragment.data)}?` : formatValue(value)
-      };
-    });
-  }
-  return [{ kind: "text", text: element.catalog_name ?? `element ${element.id}` }];
+const renderElement = (element: CpdlcElement): PhrasePart[] => {
+  if (!element.fragments.length)
+    return [{ kind: "text", text: element.catalog_name || `element ${element.id}` }];
+
+  return element.fragments.map(fragment => {
+    if ("text" in fragment) return { kind: "text", text: fragment.text };
+    const slot = fragment.value;
+    const value = resolveSlot(element, slot);
+    return {
+      kind: "value",
+      text: value === undefined ? `${label(slot)}?` : formatValue(value)
+    };
+  });
 };
 
-const sideRows = (elements: DatalinkCpdlcElement[], direction: string): PhraseRow[] =>
+const sideRows = (elements: CpdlcElement[], direction: string): PhraseRow[] =>
   elements.map(element => ({
     meta: `${controlLabel(direction)} ${element.is_additional ? "+" : "#"}${element.id}`,
     parts: renderElement(element)
   }));
 
-const isCpdlcPayload = (
-  payload: Arinc622Payload | undefined
-): payload is AdjacentPayload<"cpdlc", CpdlcPayload> => payload?.kind === "cpdlc";
-
 const rows = computed(() => {
   const arinc = arinc622Message(props.msg);
-  const payload = isCpdlcPayload(arinc?.payload) ? arinc.payload.data : null;
-  if (!payload) return [];
+  if (!arinc || !("cpdlc" in arinc.payload)) return [];
+  const payload = arinc.payload.cpdlc;
 
   const out: PhraseRow[] = [];
-  if (payload.downlink)
-    out.push(...sideRows(payload.downlink.elements ?? [], "downlink"));
-  if (payload.uplink) out.push(...sideRows(payload.uplink.elements ?? [], "uplink"));
+  if (payload.downlink) out.push(...sideRows(payload.downlink.elements, "downlink"));
+  if (payload.uplink) out.push(...sideRows(payload.uplink.elements, "uplink"));
 
   const control = payload.control;
-  const controlSide = control?.data?.message;
-  if (controlSide) {
-    out.push(...sideRows(controlSide.elements ?? [], control.kind));
+  if (control && control !== "disconnect_request") {
+    const kind = "connect_request" in control ? "connect_request" : "connect_confirm";
+    const side =
+      "connect_request" in control
+        ? control.connect_request.message
+        : control.connect_confirm.message;
+    if (side) out.push(...sideRows(side.elements, kind));
   }
   if (!out.length && control) {
-    out.push({
-      meta: "control",
-      parts: [{ kind: "text", text: controlLabel(control.kind) }]
-    });
+    const kind =
+      control === "disconnect_request"
+        ? control
+        : "connect_request" in control
+          ? "connect_request"
+          : "connect_confirm";
+    out.push({ meta: "control", parts: [{ kind: "text", text: controlLabel(kind) }] });
   }
   return out.slice(0, 4);
 });

--- a/packages/tangram_datalink/src/tangram_datalink/summary/DefaultMessage.vue
+++ b/packages/tangram_datalink/src/tangram_datalink/summary/DefaultMessage.vue
@@ -4,20 +4,20 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import type { DatalinkMessage } from "../types";
+import type { DatalinkMessage, SummaryRow } from "../types";
 import { arinc622Message, rawMessage } from "../summary_helpers";
+import { arinc622PayloadKind } from "../store";
 import SummaryRows from "./Rows.vue";
-import type { SummaryRow } from "../types";
 
 defineOptions({ name: "DatalinkSummaryDefaultMessage" });
 
 const props = defineProps<{ msg: DatalinkMessage }>();
 
 const rows = computed<SummaryRow[]>(() => {
-  const raw = rawMessage(props.msg);
-  const arinc = arinc622Message(raw);
+  const arinc = arinc622Message(rawMessage(props.msg));
+  if (!arinc) return [];
   const seen = new Set<string>();
-  const parts = [arinc?.imi, arinc?.payload?.kind].filter((value): value is string => {
+  const parts = [arinc.imi, arinc622PayloadKind(arinc.payload)].filter(value => {
     if (!value) return false;
     const key = value.toLowerCase();
     if (seen.has(key)) return false;

--- a/packages/tangram_datalink/src/tangram_datalink/summary/Miam.vue
+++ b/packages/tangram_datalink/src/tangram_datalink/summary/Miam.vue
@@ -5,20 +5,15 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { messageApp } from "../store";
-import type { DatalinkMessage } from "../types";
-import type { OhmaPayload } from "../types";
+import type { DatalinkMessage, OhmaPayload, SummaryRow } from "../types";
 import SummaryRows from "./Rows.vue";
-import type { SummaryRow } from "../types";
 
 defineOptions({ name: "DatalinkSummaryMiam" });
 
 const props = defineProps<{ msg: DatalinkMessage }>();
-
 const label = (value: string) => value.replaceAll("_", " ");
-
 const totalFlights = (data: OhmaPayload) =>
   data.airplanes.reduce((sum, airplane) => sum + (airplane.flights?.length ?? 0), 0);
-
 const totalEvents = (data: OhmaPayload) =>
   data.airplanes.reduce(
     (sum, airplane) =>
@@ -32,8 +27,9 @@ const totalEvents = (data: OhmaPayload) =>
 
 const rows = computed<SummaryRow[]>(() => {
   const app = messageApp(props.msg);
-  if (app?.kind === "ohma") {
-    const data = app.data;
+  if (!app || typeof app === "string") return [];
+  if ("ohma" in app) {
+    const data = app.ohma;
     return [
       {
         meta: "OHMA",
@@ -53,21 +49,17 @@ const rows = computed<SummaryRow[]>(() => {
       }
     ];
   }
-
-  if (app?.kind === "miam") {
-    const data = app.data;
-    const frame = data.frame_id;
-    const pdu = typeof data.core.kind === "string" ? data.core.kind : null;
+  if ("miam" in app) {
+    const data = app.miam;
+    const pdu = "Data" in data.core ? "data" : "Ack" in data.core ? "ack" : "unknown";
     return [
       {
         meta: "MIAM",
         detail:
-          [frame && label(frame), pdu && label(pdu)].filter(Boolean).join(" · ") ||
-          "decoded"
+          [label(data.frame_id), label(pdu)].filter(Boolean).join(" · ") || "decoded"
       }
     ];
   }
-
   return [];
 });
 </script>

--- a/packages/tangram_datalink/src/tangram_datalink/summary/Oooi.vue
+++ b/packages/tangram_datalink/src/tangram_datalink/summary/Oooi.vue
@@ -5,9 +5,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { messageApp } from "../store";
-import type { DatalinkMessage } from "../types";
+import type { DatalinkMessage, SummaryRow } from "../types";
 import SummaryRows from "./Rows.vue";
-import type { SummaryRow } from "../types";
 
 defineOptions({ name: "DatalinkSummaryOooi" });
 
@@ -15,8 +14,9 @@ const props = defineProps<{ msg: DatalinkMessage }>();
 
 const rows = computed<SummaryRow[]>(() => {
   const app = messageApp(props.msg);
-  if (app?.kind === "oooi_off_destination") {
-    const data = app.data;
+  if (!app || typeof app === "string") return [];
+  if ("oooi_off_destination" in app) {
+    const data = app.oooi_off_destination;
     return [
       {
         meta: "OFF dest",
@@ -25,8 +25,8 @@ const rows = computed<SummaryRow[]>(() => {
       ...(data.extras ? [{ meta: "extras", detail: data.extras }] : [])
     ];
   }
-  if (app?.kind === "oooi_off_report") {
-    const data = app.data;
+  if ("oooi_off_report" in app) {
+    const data = app.oooi_off_report;
     return [
       {
         meta: "OFF report",

--- a/packages/tangram_datalink/src/tangram_datalink/summary/Position.vue
+++ b/packages/tangram_datalink/src/tangram_datalink/summary/Position.vue
@@ -5,10 +5,13 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { messageApp } from "../store";
-import type { DatalinkMessage } from "../types";
-import type { LinkType, PositionLikePayload } from "../types";
+import type {
+  DatalinkMessage,
+  LinkType,
+  PositionLikePayload,
+  SummaryRow
+} from "../types";
 import SummaryRows from "./Rows.vue";
-import type { SummaryRow } from "../types";
 
 defineOptions({ name: "DatalinkSummaryPosition" });
 
@@ -30,24 +33,6 @@ const linkLabel = (link: LinkType) => {
     default:
       return link.toUpperCase();
   }
-};
-
-const mediaAdvisoryDetail = (data: {
-  state: string;
-  current_link: LinkType;
-  time_utc: string;
-  available_links: LinkType[];
-  text?: string;
-}) => {
-  const alternates = data.available_links.filter(link => link !== data.current_link);
-  return [
-    `${data.state.toLowerCase()} ${linkLabel(data.current_link)}`,
-    `${data.time_utc}Z`,
-    alternates.length ? `also ${alternates.map(linkLabel).join("/")}` : null,
-    data.text
-  ]
-    .filter(Boolean)
-    .join(" · ");
 };
 
 const positionRow = (
@@ -85,14 +70,25 @@ const positionRow = (
 
 const rows = computed<SummaryRow[]>(() => {
   const app = messageApp(props.msg);
-  if (app?.kind === "aoc_position") return positionRow(app.data.format, app.data);
-  if (app?.kind === "label_32")
-    return positionRow("label 32", app.data, app.data.fields);
-  if (app?.kind === "media_advisory") {
+  if (!app || typeof app === "string") return [];
+  if ("aoc_position" in app)
+    return positionRow(app.aoc_position.format, app.aoc_position);
+  if ("label_32" in app)
+    return positionRow("label 32", app.label_32, app.label_32.fields);
+  if ("media_advisory" in app) {
+    const data = app.media_advisory;
+    const alternates = data.available_links.filter(link => link !== data.current_link);
     return [
       {
         meta: "media",
-        detail: mediaAdvisoryDetail(app.data)
+        detail: [
+          `${data.state.toLowerCase()} ${linkLabel(data.current_link)}`,
+          `${data.time_utc}Z`,
+          alternates.length ? `also ${alternates.map(linkLabel).join("/")}` : null,
+          data.text
+        ]
+          .filter(Boolean)
+          .join(" · ")
       }
     ];
   }

--- a/packages/tangram_datalink/src/tangram_datalink/summary_helpers.ts
+++ b/packages/tangram_datalink/src/tangram_datalink/summary_helpers.ts
@@ -1,62 +1,39 @@
 import { toRaw } from "vue";
-import { arinc622Payload, messageApp, messageData, messageLabel } from "./store";
-import type { Arinc622Message, DatalinkMessage, JsonObject } from "./types";
+import {
+  arinc622Payload,
+  avlcAcarsMessage,
+  messageApp,
+  messageKind,
+  messageLabel
+} from "./store";
+import type { AcarsAppPayload, Arinc622Message, DatalinkMessage } from "./types";
 
-export const rawMessage = (msg: DatalinkMessage) => toRaw(msg) as DatalinkMessage;
+export const rawMessage = (msg: DatalinkMessage) => toRaw(msg);
 
-export const isRecord = (value: unknown): value is JsonObject =>
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
-
-export const adjacentData = (value: unknown): unknown =>
-  isRecord(value) && typeof value.kind === "string" && "data" in value
-    ? value.data
-    : value;
 
 export const arinc622Message = (msg: DatalinkMessage): Arinc622Message | null =>
   arinc622Payload(messageApp(rawMessage(msg)));
 
-export const decodedArincPayload = (msg: DatalinkMessage) =>
-  arinc622Message(msg)?.payload?.data ?? null;
-
-// these field readers are deliberately small compatibility shims for loose
-// Airframes payloads and unknown protocol branches.
-// new protocol-specific renderers should prefer typed payload unions from store.ts.
-export const stringField = (value: unknown, key: string): string | undefined => {
-  if (!isRecord(value)) return undefined;
-  const field = value[key];
-  return typeof field === "string" ? field : undefined;
-};
-
-export const numberField = (value: unknown, key: string): number | undefined => {
-  if (!isRecord(value)) return undefined;
-  const field = value[key];
-  return typeof field === "number" ? field : undefined;
-};
-
-export const arrayField = (value: unknown, key: string): unknown[] => {
-  if (!isRecord(value)) return [];
-  const field = value[key];
-  return Array.isArray(field) ? field : [];
-};
-
-export const appKind = (msg: DatalinkMessage): string | null => {
-  const app = messageApp(rawMessage(msg));
-  return app?.kind === "none" ? null : (app?.kind ?? null);
-};
+const appText = (app: AcarsAppPayload | null | undefined): string | undefined =>
+  app && typeof app !== "string" && "text" in app ? app.text : undefined;
 
 export const messageText = (msg: DatalinkMessage): string | undefined => {
   const raw = rawMessage(msg);
-  const data = messageData(raw);
-  const payload = data && isRecord(data.payload) ? data.payload : null;
-  return (
-    stringField(data, "text") ??
-    stringField(data, "txt") ??
-    stringField(payload, "text") ??
-    stringField(payload, "txt")
-  );
+  if ("airframes" in raw.message)
+    return raw.message.airframes.payload.text ?? appText(raw.message.airframes.app);
+  if ("acars" in raw.message)
+    return raw.message.acars.text || appText(raw.message.acars.app);
+  if ("avlc" in raw.message) {
+    const acars = avlcAcarsMessage(raw);
+    return acars?.text || appText(acars?.app);
+  }
+  if ("app" in raw.message) return appText(raw.message.app);
+  return undefined;
 };
 
 export const messageKeyParts = (msg: DatalinkMessage) => {
   const raw = rawMessage(msg);
-  return `${raw.timestamp ?? 0}:${raw.raw_frame_hex ?? ""}:${raw.message.kind}:${messageLabel(raw) ?? ""}`;
+  return `${raw.timestamp ?? 0}:${raw.raw_frame_hex ?? ""}:${messageKind(raw.message)}:${messageLabel(raw) ?? ""}`;
 };

--- a/packages/tangram_datalink/src/tangram_datalink/types.ts
+++ b/packages/tangram_datalink/src/tangram_datalink/types.ts
@@ -15,15 +15,6 @@ export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
 export type JsonObject = Record<string, unknown>;
 
-export interface AdjacentPayload<K extends string = string, D = JsonValue> {
-  kind: K;
-  data: D;
-}
-
-export interface UnitPayload<K extends string = string> {
-  kind: K;
-}
-
 export type AirframesAddrType = "aircraft" | "ground_station" | "unknown";
 
 export interface AirframesAddr {
@@ -32,23 +23,33 @@ export interface AirframesAddr {
 }
 
 export interface AirframesPayload {
-  label?: string | null;
-  text?: string | null;
-  from_hex?: string | null;
-  to_hex?: string | null;
-  latitude?: number | null;
-  longitude?: number | null;
-  altitude?: number | null;
-  track?: number | null;
-  frequency?: number | null;
-  id?: string | number | null;
-  airframe_id?: string | number | null;
-  flight_id?: string | number | null;
-  tail?: string | null;
-  link_direction?: string | null;
+  label: string | null;
+  text: string | null;
+  from_hex: string | null;
+  to_hex: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  altitude: number | null;
+  track: number | null;
+  source_type: DatalinkBearer;
+  timestamp: number | null;
+  created_at: number | null;
+  frequency: number | null;
+  id: string | null;
+  airframe_id: number | null;
+  flight_id: number | null;
+  tail: string | null;
+  link_direction: string | null;
+  airframe: { icao: string | null; tail: string | null } | null;
+  flight: {
+    latitude: number | null;
+    longitude: number | null;
+    altitude: number | null;
+    track: number | null;
+  } | null;
 }
 
-export interface SquitterPayload extends JsonObject {
+export interface SquitterPayload {
   station?: string | null;
   airport?: string | null;
   provider?: string | null;
@@ -65,252 +66,348 @@ export interface AirframesMessage {
   app?: AcarsAppPayload | null;
 }
 
+export type AcarsBlockId = { DL: number } | { UL: string };
+export type AcarsDirection = "Unknown" | "UL" | "DL";
+
 export interface AcarsMessage {
-  label?: string | null;
-  txt?: string | null;
-  text?: string | null;
-  app?: AcarsAppPayload | null;
-  payload?: JsonValue;
+  mode: string;
+  tail: string;
+  ack: string;
+  label: string;
+  block_id: AcarsBlockId;
+  msg_nb?: string;
+  sequence?: string;
+  flight_id?: string;
+  sublabel?: string;
+  text: string;
+  direction: AcarsDirection;
+  block_end: boolean;
+  app: AcarsAppPayload;
 }
 
 export type AvlcPayload =
-  | AdjacentPayload<"acars", AcarsMessage>
-  | AdjacentPayload<"xid", JsonObject>
-  | AdjacentPayload<"x25", JsonObject>
-  | AdjacentPayload<"unknown", string>;
+  | { acars: AcarsMessage }
+  | { xid: JsonObject }
+  | { x25: JsonObject }
+  | { unknown: string };
+
+export type AvlcSFunc =
+  "ReceiveReady" | "ReceiveNotReady" | "Reject" | "SelectiveReject";
+
+export type AvlcLcf =
+  | { I: { send_seq: number; poll: boolean; recv_seq: number } }
+  | { S: { sfunc: AvlcSFunc; pf: boolean; recv_seq: number } }
+  | { U: { name: string; mfunc: number; pf: boolean } };
+
+export type AvlcAddrType = "aircraft" | "ground_station" | "all_stations";
+export type AvlcFrameRole = "Command" | "Response";
+export type AvlcAircraftGroundStatus = "Airborne" | "OnGround";
 
 export interface AvlcFrame {
-  src?: { icao24: string; addr_type: string };
-  dst?: { icao24: string; addr_type: string };
-  payload?: AvlcPayload | null;
+  src: { icao24: string; addr_type: AvlcAddrType };
+  dst: { icao24: string; addr_type: AvlcAddrType };
+  role: AvlcFrameRole;
+  ag_status?: AvlcAircraftGroundStatus;
+  lcf: AvlcLcf;
+  payload?: AvlcPayload;
 }
 
-export interface Arinc622Message extends JsonObject {
-  atsu_address?: string;
-  imi?: string;
-  registration?: string;
-  payload?: Arinc622Payload;
+export interface Arinc622Message {
+  atsu_address: string;
+  imi: string;
+  registration: string;
+  payload: Arinc622Payload;
 }
+
+export type AdscDisconnectReason =
+  | "reason_not_specified"
+  | "congestion"
+  | "application_not_available"
+  | "normal_disconnect"
+  | "unknown";
 
 export type Arinc622Payload =
-  | AdjacentPayload<"adsc", AdscPayload>
-  | AdjacentPayload<"cpdlc", CpdlcPayload>
-  | AdjacentPayload<string, JsonObject>;
+  | { adsc: AdscPayload }
+  | { adsc_disconnect: AdscDisconnectReason }
+  | { cpdlc: CpdlcPayload }
+  | { aoc: { payload_hex: string } }
+  | { unknown: { payload_hex: string } };
 
 export interface AdscPositionReport {
   latitude: number;
   longitude: number;
-  altitude_ft?: number;
-  timestamp_seconds_past_hour?: number;
-  nav_redundancy_ok?: boolean;
-  position_accuracy_code?: number;
-  tcas_ok?: boolean;
+  altitude_ft: number;
+  timestamp_seconds_past_hour: number;
+  nav_redundancy_ok: boolean;
+  position_accuracy_code: number;
+  tcas_ok: boolean;
 }
 
 export interface AdscPredictedRoute {
   next_latitude: number;
   next_longitude: number;
-  next_altitude_ft?: number;
-  next_eta_seconds?: number;
-  next_next_latitude?: number;
-  next_next_longitude?: number;
-  next_next_altitude_ft?: number;
+  next_altitude_ft: number;
+  next_eta_seconds: number;
+  next_next_latitude: number;
+  next_next_longitude: number;
+  next_next_altitude_ft: number;
 }
 
-export interface AdscReferenceData {
-  heading_or_track_degrees?: number;
+export interface AdscEarthReferenceData {
+  true_track_degrees?: number;
+  track_invalid?: boolean;
+  ground_speed_kt: number;
+  vertical_speed_ft_per_min: number;
+}
+
+export interface AdscAirReferenceData {
+  true_heading_degrees?: number;
   heading_invalid?: boolean;
-  speed?: number;
-  vertical_speed_ft_per_min?: number;
+  mach: number;
+  vertical_speed_ft_per_min: number;
 }
 
 export interface AdscMeteoData {
-  wind_speed_kt?: number;
+  wind_speed_kt: number;
   wind_direction_true_degrees?: number;
   wind_direction_invalid?: boolean;
-  temperature_c?: number;
+  temperature_c: number;
 }
 
 export interface AdscFlightId {
-  id?: string;
+  callsign: string;
+}
+
+export interface AdscAirframeId {
+  /** Lowercase six-digit hexadecimal ICAO address. */
+  icao24: string;
 }
 
 export interface AdscAcknowledgement {
-  contract_number?: number;
+  contract_number: number;
 }
 
+export type AdscNackReason =
+  | "duplicate_group_tag"
+  | "duplicate_reporting_interval_tag"
+  | "event_contract_request_with_no_data"
+  | "improper_operational_mode_tag"
+  | "cancel_request_of_nonexistent_contract"
+  | "requested_contract_already_exists"
+  | "undefined_contract_request_tag"
+  | "undefined_error"
+  | "not_enough_data_in_request"
+  | "invalid_altitude_range"
+  | "vertical_speed_threshold_is_zero"
+  | "aircraft_intent_projection_time_is_zero"
+  | "lateral_deviation_threshold_is_zero"
+  | { unknown: { code: number } };
+
 export interface AdscNegativeAcknowledgement {
-  contract_request_number?: number;
-  reason?: string;
+  contract_request_number: number;
+  reason: AdscNackReason;
+  extension: number | null;
+}
+
+export type AdscNoncompliantTag =
+  | "lateral_deviation_change"
+  | "report_interval"
+  | "flight_id"
+  | "predicted_route"
+  | "earth_reference_data"
+  | "air_reference_data"
+  | "meteo_data"
+  | "airframe_id"
+  | "vertical_speed_change"
+  | "altitude_range"
+  | "report_waypoint_changes"
+  | "aircraft_intent_data"
+  | { unknown: { tag: number } };
+
+export interface AdscNoncomplianceGroup {
+  noncompliant_tag: AdscNoncompliantTag;
+  is_unrecognized: boolean;
+  is_whole_group_unavailable: boolean;
+  parameters: number[];
+}
+
+export interface AdscNoncomplianceNotification {
+  contract_request_number: number;
+  groups: AdscNoncomplianceGroup[];
 }
 
 export interface AdscCancelContract {
-  contract_number?: number;
+  contract_number: number;
 }
 
-export interface AdscProjection {
-  latitude?: number;
-  longitude?: number;
-  altitude_ft?: number;
-  eta_seconds?: number;
-  distance_nm?: number;
+export interface AdscIntermediateProjectionPayload {
+  distance_nm: number;
   track_degrees?: number;
   track_invalid?: boolean;
+  altitude_ft: number;
+  eta_seconds: number;
 }
 
-export type AdscContractGroup =
-  | AdjacentPayload<"report_interval", { interval_secs?: number }>
-  | AdjacentPayload<"flight_id", { modulus?: number }>
-  | AdjacentPayload<"predicted_route", { modulus?: number }>
-  | AdjacentPayload<"earth_reference_data", { modulus?: number }>
-  | AdjacentPayload<"air_reference_data", { modulus?: number }>
-  | AdjacentPayload<"meteo_data", { modulus?: number }>
-  | AdjacentPayload<"airframe_id", { modulus?: number }>
-  | AdjacentPayload<"lateral_deviation_change", { threshold_nm?: number }>
-  | AdjacentPayload<"vertical_speed_change", { threshold_ft_per_min?: number }>
-  | AdjacentPayload<"altitude_range", { ceiling_ft?: number; floor_ft?: number }>
-  | UnitPayload<"report_waypoint_changes">
-  | AdjacentPayload<
-      "aircraft_intent_data",
-      { modulus?: number; projection_time_mins?: number }
-    >
-  | AdjacentPayload<string, JsonObject>;
+export interface AdscFixedProjectionPayload {
+  latitude: number;
+  longitude: number;
+  altitude_ft: number;
+  eta_seconds: number;
+}
 
-export interface AdscContractRequest {
-  contract_number?: number;
-  groups?: AdscContractGroup[];
+export type AdscPeriodicReportGroup =
+  | { flight_id: { modulus: number } }
+  | { predicted_route: { modulus: number } }
+  | { earth_reference_data: { modulus: number } }
+  | { air_reference_data: { modulus: number } }
+  | { meteo_data: { modulus: number } }
+  | { airframe_id: { modulus: number } }
+  | { aircraft_intent_data: { modulus: number; projection_time_mins: number } };
+
+export type AdscEventTrigger =
+  | { lateral_deviation_change: { threshold_nm: number } }
+  | { vertical_speed_change: { threshold_ft_per_min: number } }
+  | { altitude_range: { ceiling_ft: number; floor_ft: number } }
+  | "waypoint_change";
+
+export type AdscContractGroup = AdscPeriodicReportGroup | AdscEventTrigger;
+
+export interface AdscPeriodicContractRequest {
+  contract_number: number;
+  report_interval_secs: number;
+  requested_groups: AdscPeriodicReportGroup[];
+}
+
+export interface AdscEventContractRequest {
+  contract_number: number;
+  events: AdscEventTrigger[];
 }
 
 export type AdscTag =
-  | AdjacentPayload<"acknowledgement", AdscAcknowledgement>
-  | AdjacentPayload<"negative_acknowledgement", AdscNegativeAcknowledgement>
-  | AdjacentPayload<"noncompliance_notification", JsonObject>
-  | UnitPayload<"cancel_emergency_mode">
-  | AdjacentPayload<"basic_report", AdscPositionReport>
-  | AdjacentPayload<"emergency_basic_report", AdscPositionReport>
-  | AdjacentPayload<"lateral_deviation_change_event", AdscPositionReport>
-  | AdjacentPayload<"flight_id", AdscFlightId>
-  | AdjacentPayload<"predicted_route", AdscPredictedRoute>
-  | AdjacentPayload<"earth_reference_data", AdscReferenceData>
-  | AdjacentPayload<"air_reference_data", AdscReferenceData>
-  | AdjacentPayload<"meteo_data", AdscMeteoData>
-  | AdjacentPayload<"airframe_id", JsonObject>
-  | AdjacentPayload<"vertical_rate_change_event", AdscPositionReport>
-  | AdjacentPayload<"altitude_range_event", AdscPositionReport>
-  | AdjacentPayload<"waypoint_change_event", AdscPositionReport>
-  | AdjacentPayload<"intermediate_projection", AdscProjection>
-  | AdjacentPayload<"fixed_projection", AdscProjection>
-  | UnitPayload<"cancel_all_contracts">
-  | AdjacentPayload<"cancel_contract", AdscCancelContract>
-  | AdjacentPayload<"periodic_contract_request", AdscContractRequest>
-  | AdjacentPayload<"event_contract_request", AdscContractRequest>
-  | AdjacentPayload<"emergency_periodic_contract_request", AdscContractRequest>
-  | AdjacentPayload<"unknown", JsonObject>;
+  | { acknowledgement: AdscAcknowledgement }
+  | { negative_acknowledgement: AdscNegativeAcknowledgement }
+  | { noncompliance_notification: AdscNoncomplianceNotification }
+  | "cancel_emergency_mode"
+  | { basic_report: AdscPositionReport }
+  | { emergency_basic_report: AdscPositionReport }
+  | { lateral_deviation_change_event: AdscPositionReport }
+  | { flight_id: AdscFlightId }
+  | { predicted_route: AdscPredictedRoute }
+  | { earth_reference_data: AdscEarthReferenceData }
+  | { air_reference_data: AdscAirReferenceData }
+  | { meteo_data: AdscMeteoData }
+  | { airframe_id: AdscAirframeId }
+  | { vertical_rate_change_event: AdscPositionReport }
+  | { altitude_range_event: AdscPositionReport }
+  | { waypoint_change_event: AdscPositionReport }
+  | { intermediate_projection: AdscIntermediateProjectionPayload }
+  | { fixed_projection: AdscFixedProjectionPayload }
+  | "cancel_all_contracts"
+  | { cancel_contract: AdscCancelContract }
+  | { periodic_contract_request: AdscPeriodicContractRequest }
+  | { event_contract_request: AdscEventContractRequest }
+  | { emergency_periodic_contract_request: AdscPeriodicContractRequest };
 
-export interface AdscPayload extends JsonObject {
-  tags?: AdscTag[];
-}
+export type AdscPayload = AdscTag[];
 
-export interface CpdlcPayload extends JsonObject {
+export type CpdlcControlMessage =
+  | { connect_request: { message?: CpdlcSide | null } }
+  | { connect_confirm: { message?: CpdlcSide | null } }
+  | "disconnect_request";
+
+export interface CpdlcPayload {
+  payload_hex: string;
+  payload_len_bytes: number;
   downlink?: CpdlcSide | null;
   uplink?: CpdlcSide | null;
-  control?: AdjacentPayload<string, { message?: CpdlcSide | null }> | null;
+  control?: CpdlcControlMessage | null;
 }
 
-export interface CpdlcSide extends JsonObject {
-  header?: DatalinkCpdlcMessage["header"];
-  elements?: DatalinkCpdlcElement[];
+export interface CpdlcSide {
+  header: CpdlcHeader;
+  elements: CpdlcElement[];
+  remaining_bits_after_element: number;
 }
 
 export type AcarsAppPayload =
-  | UnitPayload<"none" | "link_test">
-  | AdjacentPayload<"arinc622", Arinc622Message>
-  | AdjacentPayload<"squitter", SquitterPayload>
-  | AdjacentPayload<"text", string>
-  | AdjacentPayload<"miam", MiamPayload>
-  | AdjacentPayload<"ohma", OhmaPayload>
-  | AdjacentPayload<"media_advisory", MediaAdvisoryPayload>
-  | AdjacentPayload<"aoc_report", AocReportPayload>
-  | AdjacentPayload<"weather", WeatherPayload>
-  | AdjacentPayload<"label_5z", Label5zPayload>
-  | AdjacentPayload<"aoc_position", AocPositionPayload>
-  | AdjacentPayload<"label_32", Label32Payload>
-  | AdjacentPayload<"label_16", Label16Payload>
-  | AdjacentPayload<"label_37", Label37Payload>
-  | AdjacentPayload<"oooi_off_destination", OooiOffDestinationPayload>
-  | AdjacentPayload<"oooi_off_report", OooiOffReportPayload>
-  | AdjacentPayload<"atis_request", AtisRequestPayload>
-  | AdjacentPayload<"atis_delivery", AtisDeliveryPayload>
-  | AdjacentPayload<"afn", AfnPayload>
-  | AdjacentPayload<"oceanic_clearance", OceanicClearancePayload>;
+  | "none"
+  | "link_test"
+  | { arinc622: Arinc622Message }
+  | { squitter: SquitterPayload }
+  | { text: string }
+  | { miam: MiamPayload }
+  | { ohma: OhmaPayload }
+  | { media_advisory: MediaAdvisoryPayload }
+  | { aoc_report: AocReportPayload }
+  | { weather: WeatherPayload }
+  | { label_5z: Label5zPayload }
+  | { aoc_position: AocPositionPayload }
+  | { label_32: Label32Payload }
+  | { label_16: Label16Payload }
+  | { label_37: Label37Payload }
+  | { oooi_off_destination: OooiOffDestinationPayload }
+  | { oooi_off_report: OooiOffReportPayload }
+  | { atis_request: AtisRequestPayload }
+  | { atis_delivery: AtisDeliveryPayload }
+  | { afn: AfnPayload }
+  | { oceanic_clearance: OceanicClearancePayload };
 
 export type DatalinkProtocolMessage =
-  | AdjacentPayload<"airframes", AirframesMessage>
-  | AdjacentPayload<"avlc", AvlcFrame>
-  | AdjacentPayload<"acars", AcarsMessage>
-  | AdjacentPayload<"hfdl", JsonObject>
-  | AdjacentPayload<"app", AcarsAppPayload>;
+  | { airframes: AirframesMessage }
+  | { avlc: AvlcFrame }
+  | { acars: AcarsMessage }
+  | { hfdl: JsonObject }
+  | { app: AcarsAppPayload };
+
+export type DatalinkBearer = "vhf" | "vdl2" | "hfdl" | "decoded" | "unknown";
+export type DatalinkSourceClass = "iq" | "events" | "frames";
 
 export interface DatalinkMessage {
-  event?: string | null;
-  timestamp?: number | null;
-  bearer?: string | null;
-  source?: {
-    id?: string | null;
-    name?: string | null;
-    class?: string | null;
-    format?: string | null;
-  } | null;
-  receiver?: {
-    bearer?: string | null;
-    channel_hz?: number | null;
-  } | null;
-  aircraft?: {
-    icao24?: string | null;
-    registration?: string | null;
-    aircraft_id?: string | number | null;
+  event: string;
+  timestamp?: number;
+  bearer: DatalinkBearer;
+  source: {
+    id: string;
+    name: string;
+    class: DatalinkSourceClass;
+    format?: string;
   };
-  flight_id?: string | number | null;
+  receiver?: {
+    bearer: DatalinkBearer;
+    channel_hz?: number;
+  };
+  aircraft?: {
+    icao24?: string;
+    registration?: string;
+    aircraft_id?: number;
+  };
   kinematics?: DatalinkKinematics;
   raw_frame_hex?: string;
   message: DatalinkProtocolMessage;
 }
 
-export interface AdscContractGroupInfo {
-  kind: string;
-  interval_secs?: number;
-  modulus?: number;
-  threshold_nm?: number;
-  threshold_fpm?: number;
-  ceiling_ft?: number;
-  floor_ft?: number;
-  projection_time_mins?: number;
-}
-
-export interface AdscContractInfo {
-  kind: "periodic" | "event" | "emergency" | "cancel_all" | "cancel";
-  number?: number;
-  groups: AdscContractGroupInfo[];
-}
-
 export interface AdscIntermediateProjection {
   distance_nm: number;
-  track_degrees: number;
+  track_degrees?: number;
   track_invalid: boolean;
   altitude_ft?: number;
-  eta_secs?: number;
+  eta_seconds_past_hour?: number;
 }
 
 export interface AdscFixedProjection {
   latitude: number;
   longitude: number;
   altitude_ft?: number;
-  eta_secs?: number;
+  eta_seconds_past_hour?: number;
 }
 
 export interface DatalinkAdscReport {
   timestamp?: number;
+  /** Timestamp from the position report, encoded as seconds past the hour. */
+  report_seconds_past_hour?: number;
   registration?: string;
+  /** Lowercase six-digit hexadecimal ICAO address from AirframeId. */
+  icao24?: string;
   position?: { latitude: number; longitude: number };
   altitude_ft?: number;
   /** resolved track: EarthReferenceData (valid) → IntermediateProjection[0] → null */
@@ -326,7 +423,7 @@ export interface DatalinkAdscReport {
     latitude: number;
     longitude: number;
     altitude_ft?: number;
-    eta_secs?: number;
+    eta_seconds_past_hour?: number;
   };
   /** PredictedRoute next+1 waypoint (absolute lat/lon) */
   next_next?: { latitude: number; longitude: number; altitude_ft?: number };
@@ -337,40 +434,29 @@ export interface DatalinkAdscReport {
   wind_speed_kt?: number;
   wind_direction_deg?: number;
   temperature_c?: number;
-  /** true when this is an uplink (ground→aircraft) contract request */
-  is_uplink?: boolean;
-  /** structured contract info for uplink messages */
-  contract?: AdscContractInfo;
-  raw_tags: string[];
 }
 
-export type CpdlcElementBody = AdjacentPayload<string, JsonValue>;
-export type CpdlcPhraseFragment =
-  AdjacentPayload<"text", string> | AdjacentPayload<"value", string>;
+export type CpdlcElementBody = Record<string, JsonValue> | "unsupported";
+export type CpdlcPhraseFragment = { text: string } | { value: string };
 
-export interface DatalinkCpdlcElement {
+export interface CpdlcElement {
   id: number;
-  catalog_name?: string;
+  catalog_name: string;
   fragments: CpdlcPhraseFragment[];
   body?: CpdlcElementBody | null;
   is_additional: boolean;
 }
 
 export interface CpdlcTimestamp {
-  hour?: number;
-  minute?: number;
-  second?: number;
+  hour: number;
+  minute: number;
+  second: number;
 }
 
-export interface DatalinkCpdlcMessage {
-  timestamp?: number;
-  atsu_address?: string;
-  registration?: string;
-  imi?: string;
-  direction?: "downlink" | "uplink";
-  header?: { msg_id?: number; msg_ref?: number; timestamp?: CpdlcTimestamp };
-  elements: DatalinkCpdlcElement[];
-  control_type?: string;
+export interface CpdlcHeader {
+  msg_id: number;
+  msg_ref?: number;
+  timestamp?: CpdlcTimestamp;
 }
 
 export interface AfnApplication {
@@ -527,10 +613,9 @@ export interface AocReportPayload {
 }
 
 export type MiamCorePdu =
-  | { kind: "data"; data: LoosePayloadObject }
-  | { kind: "ack"; data: LoosePayloadObject }
-  | { kind: "unknown"; data: LoosePayloadObject }
-  | LoosePayloadObject;
+  | { Data: { header: LoosePayloadObject; body?: LoosePayloadObject | null } }
+  | { Ack: LoosePayloadObject }
+  | { Unknown: { pdu_type: number; version: number } };
 
 export interface MiamPayload extends LoosePayloadObject {
   frame_id: string;


### PR DESCRIPTION
- switch from adjacently tagged enums to externally tagged, see: https://github.com/xoolive/datalink/commit/9e91e189ef89df932ccb9794fc8cb4507993d58e
- fallback to system time for timestamp-less entities instead of discarding
- model serde enums as direct externally tagged TypeScript unions
- update ADS-C tags, contracts, projections and semantic error details
- render ADS-C disconnects, noncompliance, airframe IDs and reference data
- update CPDLC controls, phrase fragments, bodies and speed formatting
- correct ADS-C ETA and route ordering across hour boundaries
- extract nested AVLC ACARS text and flight identities
- avoid projecting an intermediate ADS-C intent point without a valid track
- remove legacy format compatibility fallback