### PR TITLE
feat: import zstd-compressed JSONL

### DIFF
--- a/packages/tangram_core/package.json
+++ b/packages/tangram_core/package.json
@@ -58,6 +58,7 @@
     "@fontsource/roboto-condensed": "^5.3.0",
     "@protomaps/basemaps": "^5.7.2",
     "@vitejs/plugin-vue": "^6.0.8",
+    "fzstd": "^0.1.1",
     "lit-html": "^3.3.3",
     "maplibre-gl": "^5.24.0",
     "parquet-wasm": "^0.7.2",

--- a/packages/tangram_core/src/tangram_core/utils.test.ts
+++ b/packages/tangram_core/src/tangram_core/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { isJsonlFile, parseJsonlRows } from "./utils";
+
+const compressedJsonl = Uint8Array.from(
+  Buffer.from(
+    "KLUv/QRY7QEAFAN7ImljYW8yNCI6ImFiYzEyMyIsImxhdGl0dWRlIjo0OC44LCJsb25nMi4zfQo5NH0KAwCgE1cNDXJnGWBUVoE=",
+    "base64"
+  )
+);
+
+describe("JSONL imports", () => {
+  it("recognizes and decompresses .jsonl.zst files", async () => {
+    const file = {
+      metadata: {
+        name: "history.jsonl.zst",
+        extension: ".zst",
+        mediaType: "application/zstd"
+      },
+      rawFile: {} as File,
+      getBytes: async () => compressedJsonl,
+      getText: async () => {
+        throw new Error("compressed files must be read as bytes");
+      }
+    };
+
+    expect(isJsonlFile(file)).toBe(true);
+    await expect(parseJsonlRows(file)).resolves.toEqual([
+      { icao24: "abc123", latitude: 48.8, longitude: 2.3 },
+      { icao24: "abc123", latitude: 48.9, longitude: 2.4 }
+    ]);
+  });
+});

--- a/packages/tangram_core/src/tangram_core/utils.ts
+++ b/packages/tangram_core/src/tangram_core/utils.ts
@@ -1,10 +1,13 @@
+import { decompress } from "fzstd";
 import type { LazyImportFile, MapBounds, TimeRange } from "./api";
 
 // adapted from: https://github.com/color-js/color.js/blob/main/src/spaces/oklch.js
 type Vector3 = [number, number, number];
 
 export type ColorSpec =
-  string | [number, number, number] | [number, number, number, number];
+  | string
+  | [number, number, number]
+  | [number, number, number, number];
 
 export type DeckGLColor = [number, number, number, number];
 
@@ -211,8 +214,13 @@ export function parseCsvRows(
     );
 }
 
+export function isJsonlFile(file: Pick<LazyImportFile, "metadata">): boolean {
+  const name = file.metadata.name.toLowerCase();
+  return file.metadata.extension === ".jsonl" || name.endsWith(".jsonl.zst");
+}
+
 export async function parseJsonlRows(
-  file: Pick<LazyImportFile, "rawFile" | "getText">,
+  file: Pick<LazyImportFile, "metadata" | "rawFile" | "getBytes" | "getText">,
   maxRows?: number,
   tolerateErrors = false
 ): Promise<Record<string, unknown>[]> {
@@ -236,6 +244,17 @@ export async function parseJsonlRows(
 
     return !(maxRows && rows.length >= maxRows);
   };
+
+  if (file.metadata.name.toLowerCase().endsWith(".jsonl.zst")) {
+    const text = new TextDecoder().decode(decompress(await file.getBytes()));
+    for (const line of text.split(/\r?\n/)) {
+      if (!parseLine(line)) {
+        return rows;
+      }
+    }
+
+    return rows;
+  }
 
   const stream = file.rawFile.stream?.();
   if (stream) {

--- a/packages/tangram_explore/src/tangram_explore/file_import.ts
+++ b/packages/tangram_explore/src/tangram_explore/file_import.ts
@@ -7,6 +7,7 @@ import {
   type WorkspaceImporter
 } from "@open-aviation/tangram-core/api";
 import {
+  isJsonlFile,
   isRecord,
   parseCsvRows,
   parseJsonlRows
@@ -224,7 +225,7 @@ function createExploreImporters(pluginId: string): WorkspaceImporter[] {
     pluginId,
     priority: 5,
     accepts: async file => {
-      if (file.metadata.extension !== ".jsonl") return false;
+      if (!isJsonlFile(file)) return false;
       const rows = await jsonlSample(file);
       return (
         detectTrajectoryOptions(rows, {

--- a/packages/tangram_explore/src/tangram_explore/trajectory_import.ts
+++ b/packages/tangram_explore/src/tangram_explore/trajectory_import.ts
@@ -191,7 +191,7 @@ export function detectTrajectoryOptions(
 }
 
 export async function jsonlSample(
-  file: Pick<LazyImportFile, "rawFile" | "getText">
+  file: Pick<LazyImportFile, "metadata" | "rawFile" | "getBytes" | "getText">
 ): Promise<Record<string, unknown>[]> {
   return parseJsonlRows(file, 20, true);
 }

--- a/packages/tangram_jet1090/src/tangram_jet1090/imported_trajectory.ts
+++ b/packages/tangram_jet1090/src/tangram_jet1090/imported_trajectory.ts
@@ -9,6 +9,7 @@ import {
   computeBoundsFromRecords,
   finiteNumber,
   interpolateBearing,
+  isJsonlFile,
   isRecord,
   parseJsonlRows,
   parseTimestamp,
@@ -237,7 +238,7 @@ export function isJet1090ImportedHistoryDataset(
 }
 
 export async function acceptsRs1090Jsonl(file: LazyImportFile): Promise<boolean> {
-  if (file.metadata.extension !== ".jsonl") return false;
+  if (!isJsonlFile(file)) return false;
   const sample = await parseJsonlRows(file, 20, true);
   return sample.some(
     row => "icao24" in row && ("frame" in row || "bds" in row || "df" in row)

--- a/packages/tangram_ship162/src/tangram_ship162/imported_trajectory.ts
+++ b/packages/tangram_ship162/src/tangram_ship162/imported_trajectory.ts
@@ -7,6 +7,7 @@ import { segmentTrajectoryRecords } from "@open-aviation/tangram-core/trajectory
 import {
   computeBoundsFromRecords,
   finiteNumber,
+  isJsonlFile,
   parseJsonlRows,
   parseTimestamp
 } from "@open-aviation/tangram-core/utils";
@@ -115,7 +116,7 @@ export function isShip162ImportedHistoryDataset(
 }
 
 export async function acceptsShip162Jsonl(file: LazyImportFile): Promise<boolean> {
-  if (file.metadata.extension !== ".jsonl") return false;
+  if (!isJsonlFile(file)) return false;
   const sample = await parseJsonlRows(file, 20, true);
   return sample.some(
     row =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
         version: 6.0.8(vite@8.2.2(@types/node@26.1.2)(jiti@2.7.0))(vue@3.5.40(typescript@6.0.3))
+      fzstd:
+        specifier: ^0.1.1
+        version: 0.1.1
       lit-html:
         specifier: ^3.3.3
         version: 3.3.3
@@ -1971,6 +1974,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fzstd@0.1.1:
+    resolution: {integrity: sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==}
 
   geodesy-fn@1.2.2:
     resolution: {integrity: sha512-m837H6/kNxfHiS6sXkQgPsRzfs2NkSUJx9l0n/S83X9oC5oq83jZWpntRQEhbXN2J7c+lqwesxKQnT5tMqMWNw==}
@@ -5477,6 +5483,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  fzstd@0.1.1: {}
 
   geodesy-fn@1.2.2: {}
 


### PR DESCRIPTION
## Summary
- recognize `.jsonl.zst` files as JSONL imports
- decompress Zstandard payloads before parsing JSONL rows
- support compressed trajectory, Jet1090, and Ship162 imports

## Validation
- `pnpm typecheck`
- `pnpm typecheck:vite`
- `pnpm --filter @open-aviation/tangram-core test`