### PR TITLE
feat: recognize FlightRadar24 JSON flight exports

### DIFF
--- a/packages/tangram_explore/src/tangram_explore/ExploreLayers.vue
+++ b/packages/tangram_explore/src/tangram_explore/ExploreLayers.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { watch, inject, onUnmounted, shallowReactive, computed } from "vue";
-import { GeoJsonLayer, PathLayer, ScatterplotLayer } from "@deck.gl/layers";
+import { GeoJsonLayer, IconLayer, PathLayer, ScatterplotLayer } from "@deck.gl/layers";
 import { PathStyleExtension, type PathStyleExtensionProps } from "@deck.gl/extensions";
 import type { PickingInfo } from "@deck.gl/core";
 import type { Table } from "apache-arrow";
@@ -80,6 +80,9 @@ const FALLBACK_ACCENT_COLOR = "oklch(0.5616 0.0895 251.64)";
 const SELECTED_TRAJECTORY_COLOR: [number, number, number, number] = [
   255, 255, 255, 255
 ];
+const AIRCRAFT_ICON_URL = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-16 -16 32 32"><path fill="#f9fd15" stroke="#0014aa" stroke-width="1.5" d="M0-15 4-3 13 1 13 5 3 3 2 14H-2L-3 3-13 5-13 1-4-3Z"/></svg>'
+)}`;
 
 function withAlpha(color: number[], alpha: number): [number, number, number, number] {
   return [color[0] ?? 128, color[1] ?? 128, color[2] ?? 128, alpha];
@@ -422,60 +425,90 @@ watch(
         continue;
       }
 
-      const markerLayer = new ScatterplotLayer<{
+      const markerData = data as {
         trajectory: Trajectory;
         point: Trajectory["points"][number];
-      }>({
-        id: `explore-current-${entry.id}`,
-        data,
-        visible: entry.visible,
-        pickable: opts.pickable,
-        opacity: opts.opacity * opacityMultiplier,
-        stroked: true,
-        filled: true,
-        radiusScale: 1,
-        radiusMinPixels: Math.max(opts.line_width + 3, 4),
-        radiusMaxPixels: Math.max(opts.line_width + 3, 4),
-        lineWidthMinPixels: 1.5,
-        getPosition: ({ point }) => [
-          point.longitude,
-          point.latitude,
-          is3d ? (point.altitude ?? 0) : 0
-        ],
-        getFillColor: ({ trajectory }) => {
-          if (trajectory.id === currentSelectedTrajectoryId) {
-            return SELECTED_TRAJECTORY_COLOR;
-          }
-          return (
-            parseColorSpec(trajectoryColor(trajectory, opts)) ??
-            defaultFeatureFillColor()
-          );
-        },
-        getLineColor: ({ trajectory }) => {
-          if (trajectory.id === currentSelectedTrajectoryId) {
-            return SELECTED_TRAJECTORY_COLOR;
-          }
-          return defaultFeatureLineColor();
-        },
-        onHover: (info: PickingInfo<{ trajectory: Trajectory }>) => {
-          setHoverInfo(
-            entry,
-            info.x,
-            info.y,
-            info.object?.trajectory.properties ?? null
-          );
-        },
-        onClick: (info: PickingInfo<{ trajectory: Trajectory }>) => {
-          if (!info.object) return false;
-          selectExploreTrajectory(entry.id, info.object.trajectory);
-          return true;
-        },
-        updateTriggers: {
-          getPosition: [currentTime, is3d],
-          getFillColor: [opts, currentSelectedTrajectoryId],
-          getLineColor: [currentSelectedTrajectoryId]
-        }
-      });
+      }[];
+      const usesAircraftMarker = entry.payload.trajectories.some(
+        trajectory => trajectory.properties.marker === "aircraft"
+      );
+      const onMarkerHover = (info: PickingInfo<{ trajectory: Trajectory }>) => {
+        setHoverInfo(entry, info.x, info.y, info.object?.trajectory.properties ?? null);
+      };
+      const onMarkerClick = (info: PickingInfo<{ trajectory: Trajectory }>) => {
+        if (!info.object) return false;
+        selectExploreTrajectory(entry.id, info.object.trajectory);
+        return true;
+      };
+      const markerLayer = usesAircraftMarker
+        ? new IconLayer<(typeof markerData)[number]>({
+            id: `explore-current-${entry.id}`,
+            data: markerData,
+            visible: entry.visible,
+            pickable: opts.pickable,
+            opacity: opts.opacity * opacityMultiplier,
+            billboard: false,
+            sizeScale: 1,
+            getIcon: () => ({
+              url: AIRCRAFT_ICON_URL,
+              width: 32,
+              height: 32,
+              anchorY: 16
+            }),
+            getSize: 30,
+            getPosition: ({ point }) => [
+              point.longitude,
+              point.latitude,
+              is3d ? (point.altitude ?? 0) : 0
+            ],
+            getAngle: ({ point }) => -(point.heading ?? 0),
+            onHover: onMarkerHover,
+            onClick: onMarkerClick,
+            updateTriggers: {
+              getPosition: [currentTime, is3d],
+              getAngle: [currentTime]
+            }
+          })
+        : new ScatterplotLayer<(typeof markerData)[number]>({
+            id: `explore-current-${entry.id}`,
+            data: markerData,
+            visible: entry.visible,
+            pickable: opts.pickable,
+            opacity: opts.opacity * opacityMultiplier,
+            stroked: true,
+            filled: true,
+            radiusScale: 1,
+            radiusMinPixels: Math.max(opts.line_width + 3, 4),
+            radiusMaxPixels: Math.max(opts.line_width + 3, 4),
+            lineWidthMinPixels: 1.5,
+            getPosition: ({ point }) => [
+              point.longitude,
+              point.latitude,
+              is3d ? (point.altitude ?? 0) : 0
+            ],
+            getFillColor: ({ trajectory }) => {
+              if (trajectory.id === currentSelectedTrajectoryId) {
+                return SELECTED_TRAJECTORY_COLOR;
+              }
+              return (
+                parseColorSpec(trajectoryColor(trajectory, opts)) ??
+                defaultFeatureFillColor()
+              );
+            },
+            getLineColor: ({ trajectory }) => {
+              if (trajectory.id === currentSelectedTrajectoryId) {
+                return SELECTED_TRAJECTORY_COLOR;
+              }
+              return defaultFeatureLineColor();
+            },
+            onHover: onMarkerHover,
+            onClick: onMarkerClick,
+            updateTriggers: {
+              getPosition: [currentTime, is3d],
+              getFillColor: [opts, currentSelectedTrajectoryId],
+              getLineColor: [currentSelectedTrajectoryId]
+            }
+          });
 
       if (!trajectoryPointDisposables.has(entry.id)) {
         trajectoryPointDisposables.set(

--- a/packages/tangram_explore/src/tangram_explore/file_import.ts
+++ b/packages/tangram_explore/src/tangram_explore/file_import.ts
@@ -21,6 +21,7 @@ import { createFeatureSourceFromGeoJson } from "./feature_source";
 import {
   detectTrajectoryOptions,
   extractTrajectoryJsonRows,
+  isFlightRadar24FlightJson,
   jsonlSample,
   rowsToTrajectories
 } from "./trajectory_import";
@@ -196,7 +197,8 @@ function createExploreImporters(pluginId: string): WorkspaceImporter[] {
       }
     },
     parse: async file => {
-      const rows = extractTrajectoryJsonRows(await file.getJson(), file.metadata.name);
+      const json = await file.getJson();
+      const rows = extractTrajectoryJsonRows(json, file.metadata.name);
       if (!rows) {
         throw new Error(
           `${file.metadata.name} does not look like a trajectory JSON file.`
@@ -205,7 +207,8 @@ function createExploreImporters(pluginId: string): WorkspaceImporter[] {
 
       const options = detectTrajectoryOptions(rows, {
         format: "trajectory-json",
-        file: file.metadata.name
+        file: file.metadata.name,
+        ...(isFlightRadar24FlightJson(json) ? { marker: "aircraft" } : {})
       });
       if (!options) {
         throw new Error(

--- a/packages/tangram_explore/src/tangram_explore/trajectory_import.test.ts
+++ b/packages/tangram_explore/src/tangram_explore/trajectory_import.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractTrajectoryJsonRows,
+  isFlightRadar24FlightJson,
+  rowsToTrajectories
+} from "./trajectory_import";
+
+describe("FlightRadar24 JSON imports", () => {
+  it("extracts the track from an API response envelope", () => {
+    const flightRadar24Json = {
+      result: {
+        response: {
+          data: {
+            flight: {
+              identification: {
+                number: { default: "AY1047" },
+                callsign: "FIN8NP"
+              },
+              track: [
+                {
+                  latitude: 60.314777,
+                  longitude: 24.973862,
+                  altitude: { feet: 0 },
+                  speed: { kts: 0 },
+                  verticalSpeed: { fpm: 0 },
+                  heading: 233,
+                  timestamp: 1788433025
+                },
+                {
+                  latitude: 60.314812,
+                  longitude: 24.974081,
+                  altitude: { feet: 25 },
+                  speed: { kts: 3 },
+                  verticalSpeed: { fpm: 128 },
+                  heading: 234,
+                  timestamp: 1788433072
+                }
+              ]
+            }
+          }
+        }
+      }
+    };
+    const rows = extractTrajectoryJsonRows(flightRadar24Json, "417c6ef2.json");
+
+    expect(isFlightRadar24FlightJson(flightRadar24Json)).toBe(true);
+    expect(rows).toEqual([
+      {
+        callsign: "FIN8NP",
+        latitude: 60.314777,
+        longitude: 24.973862,
+        timestamp: 1788433025,
+        altitude: 0,
+        speed: 0,
+        vertical_rate: 0,
+        heading: 233,
+        track: 233
+      },
+      {
+        callsign: "FIN8NP",
+        latitude: 60.314812,
+        longitude: 24.974081,
+        timestamp: 1788433072,
+        altitude: 25,
+        speed: 3,
+        vertical_rate: 128,
+        heading: 234,
+        track: 234
+      }
+    ]);
+
+    expect(isFlightRadar24FlightJson([{ latitude: 60, longitude: 25 }])).toBe(false);
+
+    expect(
+      rowsToTrajectories(rows ?? [], {
+        idFields: ["callsign"],
+        latitudeFields: ["latitude"],
+        longitudeFields: ["longitude"],
+        timestampFields: ["timestamp"],
+        altitudeFields: ["altitude"],
+        speedFields: ["speed"],
+        headingFields: ["heading"],
+        trackFields: ["track"],
+        splitThresholdSeconds: 600,
+        defaultProperties: { format: "trajectory-json" }
+      })
+    ).toMatchObject([
+      {
+        id: "FIN8NP",
+        label: "FIN8NP",
+        points: [
+          { latitude: 60.314777, longitude: 24.973862, altitude: 0 },
+          { latitude: 60.314812, longitude: 24.974081, altitude: 25 }
+        ]
+      }
+    ]);
+  });
+});

--- a/packages/tangram_explore/src/tangram_explore/trajectory_import.ts
+++ b/packages/tangram_explore/src/tangram_explore/trajectory_import.ts
@@ -88,21 +88,37 @@ function positionPart(row: Record<string, unknown>, index: 0 | 1): number | null
   return finiteNumber(parts[index]);
 }
 
+export function isFlightRadar24FlightJson(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    isRecord(value.result) &&
+    isRecord(value.result.response) &&
+    isRecord(value.result.response.data) &&
+    isRecord(value.result.response.data.flight) &&
+    Array.isArray(value.result.response.data.flight.track)
+  );
+}
+
 function normalizeFlightRadarTrackJson(
   value: Record<string, unknown>,
   fallbackId: string
 ): Record<string, unknown>[] | null {
-  if (!Array.isArray(value.track)) {
+  // FlightRadar24 exports wrap the response once more in a `result` object.
+  const response = isRecord(value.result) ? value.result.response : value.response;
+  const flight =
+    isRecord(response) && isRecord(response.data) ? response.data.flight : value;
+
+  if (!isRecord(flight) || !Array.isArray(flight.track)) {
     return null;
   }
 
-  const identification = isRecord(value.identification) ? value.identification : {};
+  const identification = isRecord(flight.identification) ? flight.identification : {};
   const number = isRecord(identification.number)
     ? identification.number.default
     : undefined;
   const callsign = identification.callsign ?? number ?? fallbackId;
 
-  return value.track.filter(isRecord).map(row => ({
+  return flight.track.filter(isRecord).map(row => ({
     callsign,
     latitude: row.latitude,
     longitude: row.longitude,

--- a/packages/tangram_jet1090/src/tangram_jet1090/imported_trajectory.test.ts
+++ b/packages/tangram_jet1090/src/tangram_jet1090/imported_trajectory.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  acceptsFlightRadar24Json,
+  parseFlightRadar24Json
+} from "./imported_trajectory";
+
+const flightRadar24Json = {
+  result: {
+    response: {
+      data: {
+        flight: {
+          identification: {
+            id: "417c6ef2",
+            number: { default: "AY1047" },
+            callsign: "FIN8NP"
+          },
+          aircraft: {
+            model: { code: "AT75" },
+            identification: { modes: "4601F6", registration: "OH-ATI" }
+          },
+          track: [
+            {
+              latitude: 60.314777,
+              longitude: 24.973862,
+              altitude: { feet: 0 },
+              speed: { kts: 0 },
+              verticalSpeed: { fpm: 0 },
+              heading: 233,
+              timestamp: 1788433025
+            },
+            {
+              latitude: 60.314812,
+              longitude: 24.974081,
+              altitude: { feet: 25 },
+              speed: { kts: 3 },
+              verticalSpeed: { fpm: 128 },
+              heading: 234,
+              timestamp: 1788433072
+            }
+          ]
+        }
+      }
+    }
+  }
+};
+
+const file = {
+  metadata: {
+    name: "417c6ef2.json",
+    extension: ".json",
+    mediaType: "application/json"
+  },
+  getJson: async () => flightRadar24Json
+};
+
+describe("FlightRadar24 JSON imports", () => {
+  it("dispatches a recognized flight to the aircraft-history renderer", async () => {
+    expect(await acceptsFlightRadar24Json(file as never)).toBe(true);
+
+    await expect(parseFlightRadar24Json(file as never)).resolves.toMatchObject([
+      {
+        kind: "jet1090_imported_history",
+        label: "417c6ef2.json",
+        timeRange: { start: 1788433025, stop: 1788433072 },
+        payload: {
+          recordCount: 2,
+          flights: [
+            [
+              {
+                icao24: "4601f6",
+                callsign: "FIN8NP",
+                registration: "OH-ATI",
+                typecode: "AT75",
+                track: 233
+              },
+              {
+                icao24: "4601f6",
+                callsign: "FIN8NP",
+                registration: "OH-ATI",
+                typecode: "AT75",
+                track: 234
+              }
+            ]
+          ]
+        }
+      }
+    ]);
+  });
+
+  it("does not claim arbitrary trajectory JSON", async () => {
+    expect(
+      await acceptsFlightRadar24Json({
+        ...file,
+        getJson: async () => [{ latitude: 60, longitude: 25, timestamp: 1 }]
+      } as never)
+    ).toBe(false);
+  });
+});

--- a/packages/tangram_jet1090/src/tangram_jet1090/imported_trajectory.ts
+++ b/packages/tangram_jet1090/src/tangram_jet1090/imported_trajectory.ts
@@ -237,6 +237,120 @@ export function isJet1090ImportedHistoryDataset(
   );
 }
 
+function flightRadar24Flight(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value) || !isRecord(value.result) || !isRecord(value.result.response)) {
+    return null;
+  }
+
+  const data = value.result.response.data;
+  if (!isRecord(data) || !isRecord(data.flight) || !Array.isArray(data.flight.track)) {
+    return null;
+  }
+
+  return data.flight;
+}
+
+function normalizeFlightRadar24Flight(
+  flight: Record<string, unknown>,
+  fallbackId: string
+): Jet1090Aircraft[] {
+  const identification = isRecord(flight.identification) ? flight.identification : {};
+  const aircraft = isRecord(flight.aircraft) ? flight.aircraft : {};
+  const aircraftIdentification = isRecord(aircraft.identification)
+    ? aircraft.identification
+    : {};
+  const model = isRecord(aircraft.model) ? aircraft.model : {};
+  const flightNumber = isRecord(identification.number)
+    ? identification.number.default
+    : undefined;
+  const callsign =
+    String(identification.callsign ?? flightNumber ?? "").trim() || undefined;
+  const icao24 =
+    String(aircraftIdentification.modes ?? identification.id ?? fallbackId)
+      .trim()
+      .toLowerCase() || fallbackId;
+
+  return flight.track.filter(isRecord).flatMap(row => {
+    const latitude = finiteNumber(row.latitude);
+    const longitude = finiteNumber(row.longitude);
+    const timestamp = parseTimestamp(row.timestamp);
+    if (latitude === null || longitude === null || timestamp === null) return [];
+
+    const altitude = isRecord(row.altitude) ? row.altitude.feet : row.altitude;
+    const speed = isRecord(row.speed) ? row.speed.kts : row.speed;
+    const verticalSpeed = isRecord(row.verticalSpeed)
+      ? row.verticalSpeed.fpm
+      : row.verticalSpeed;
+    const heading = finiteNumber(row.heading) ?? undefined;
+
+    return [
+      {
+        icao24,
+        lastseen: Math.round(timestamp * 1_000_000),
+        callsign,
+        registration:
+          String(aircraftIdentification.registration ?? "").trim() || undefined,
+        typecode: String(model.code ?? "").trim() || undefined,
+        latitude,
+        longitude,
+        altitude: finiteNumber(altitude) ?? undefined,
+        groundspeed: finiteNumber(speed) ?? undefined,
+        vertical_rate: finiteNumber(verticalSpeed) ?? undefined,
+        track: heading,
+        heading,
+        count: 1,
+        timestamp
+      }
+    ];
+  });
+}
+
+export async function acceptsFlightRadar24Json(file: LazyImportFile): Promise<boolean> {
+  if (file.metadata.extension !== ".json") return false;
+
+  try {
+    const flight = flightRadar24Flight(await file.getJson());
+    return (
+      flight !== null &&
+      normalizeFlightRadar24Flight(flight, file.metadata.name).length >= 2
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function parseFlightRadar24Json(
+  file: LazyImportFile
+): Promise<WorkspaceDatasetInput[]> {
+  const flight = flightRadar24Flight(await file.getJson());
+  if (!flight) {
+    throw new Error(
+      `${file.metadata.name} does not look like a FlightRadar24 flight JSON file.`
+    );
+  }
+
+  const records = normalizeFlightRadar24Flight(flight, file.metadata.name);
+  if (records.length < 2) {
+    throw new Error(
+      `${file.metadata.name} does not contain a valid FlightRadar24 track.`
+    );
+  }
+
+  return [
+    {
+      kind: JET1090_IMPORTED_HISTORY_KIND,
+      label: file.metadata.name,
+      payload: buildImportedPayload(records),
+      timeRange: importedAircraftTimeRange(records),
+      bounds: computeBoundsFromRecords(
+        records,
+        record => record.longitude,
+        record => record.latitude
+      )
+    }
+  ];
+}
+
 export async function acceptsRs1090Jsonl(file: LazyImportFile): Promise<boolean> {
   if (!isJsonlFile(file)) return false;
   const sample = await parseJsonlRows(file, 20, true);

--- a/packages/tangram_jet1090/src/tangram_jet1090/index.ts
+++ b/packages/tangram_jet1090/src/tangram_jet1090/index.ts
@@ -34,7 +34,9 @@ import {
 } from "./store";
 import {
   JET1090_IMPORTED_HISTORY_KIND,
+  acceptsFlightRadar24Json,
   acceptsRs1090Jsonl,
+  parseFlightRadar24Json,
   parseRs1090Jsonl
 } from "./imported_trajectory";
 
@@ -100,6 +102,16 @@ export async function install(ctx: PluginContext, config?: Jet1090FrontendConfig
     api.ui.registerWorkspaceComponents(JET1090_IMPORTED_HISTORY_KIND, {
       pluginId: ctx.id,
       chip: Jet1090DatasetChip
+    })
+  );
+
+  ctx.onDispose(
+    api.import.registerImporter({
+      id: "flightradar24-json",
+      pluginId: ctx.id,
+      priority: 250,
+      accepts: acceptsFlightRadar24Json,
+      parse: parseFlightRadar24Json
     })
   );
 


### PR DESCRIPTION
## Summary
- detect FlightRadar24 flight JSON through its `result.response.data.flight.track` schema rather than the `.json` extension
- normalize recognized tracks into jet1090 aircraft history when that importer is available
- retain an Explore-side aircraft-icon fallback, so recognized imports render an oriented aircraft marker and timed path even without the jet1090 importer
- preserve generic JSON trajectory import as the fallback for non-FlightRadar data

## Deliberately not included
FlightRadar24 CSV exports such as `Timestamp, UTC, Callsign, Position, Altitude, Speed, Direction` still use the generic trajectory CSV importer and dot marker. Their schema is recognizable, but CSV aircraft dispatch is intentionally deferred to keep this PR scoped to the requested JSON export.

## Validation
- `pnpm --filter @open-aviation/tangram-core test`
- focused Explore and jet1090 Vitest importer tests
- `pnpm typecheck:vite`
- production builds for `@open-aviation/tangram-explore` and `@open-aviation/tangram-jet1090`